### PR TITLE
add global export

### DIFF
--- a/global.js
+++ b/global.js
@@ -1,0 +1,1 @@
+globalThis.__dd_collector = require('.')


### PR DESCRIPTION
Used for testing in dd-trace-js without having to explicitly require to avoid things like bundler issues.