### PR TITLE
fix loader and split tests

### DIFF
--- a/load.js
+++ b/load.js
@@ -18,12 +18,8 @@ function load (name) {
   const root = __dirname
   const build = `${root}/build/Release/${name}.node`
 
-  return maybeRequire(build) || maybeRequire(find(root, name))
-}
-
-function maybeRequire (name) {
   try {
-    return runtimeRequire(path.join(root, `${name}.node`))
+    return runtimeRequire(build) || runtimeRequire(find(root, name))
   } catch (e) {
     // Not found, skip.
   }
@@ -34,7 +30,7 @@ function find (root, name) {
 
   if (!folder) return
 
-  return findFile (root, folder, name)
+  return findFile(root, folder, name)
 }
 
 function findFolder (root) {

--- a/test.js
+++ b/test.js
@@ -1,8 +1,7 @@
-const { pipeline } = require('.')
+'use strict'
 
-if (pipeline) {
-  pipeline.init_trace_exporter("127.0.0.1", 8126, 10000, "1.0", "nodejs", "18.0", "v8")
+const fs = require('fs')
 
-  let ret = pipeline.send_traces(Buffer.alloc(1), 1)
-  console.log(ret)
-}
+fs.readdirSync('test').forEach(file => {
+  require('./test/' + file)
+})

--- a/test/pipeline.js
+++ b/test/pipeline.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const { pipeline } = require('..')
+
+if (pipeline) {
+  pipeline.init_trace_exporter("127.0.0.1", 8126, 10000, "1.0", "nodejs", "18.0", "v8")
+
+  let ret = pipeline.send_traces(Buffer.alloc(1), 1)
+  console.log(ret)
+}


### PR DESCRIPTION
This PR fixes the loader which didn't use the right build folder and errored when the `prebuilds` folder didn't exist, and it splits tests in multiple files.