### PR TITLE
expose finding bindings and load externally

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
 'use strict'
 
-const { find, load } = require('./load')
-
-module.exports = { find, load }
+module.exports = require('./load')

--- a/index.js
+++ b/index.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const load = require('./load')
+const { find, load } = require('./load')
 
-module.exports = {
-  get collector () { return load('collector') },
-  get pipeline () { return load('pipeline') }
-}
+module.exports = { find, load }

--- a/load.js
+++ b/load.js
@@ -15,22 +15,25 @@ const inWebpack = typeof __webpack_require__ === 'function'
 const runtimeRequire = inWebpack ? __non_webpack_require__ : require
 
 function load (name) {
-  const root = __dirname
-  const build = `${root}/build/Release/${name}.node`
-
   try {
-    return runtimeRequire(build) || runtimeRequire(find(root, name))
+    return runtimeRequire(find(name))
   } catch (e) {
     // Not found, skip.
   }
 }
 
-function find (root, name) {
+function find (name, binary = false) {
+  const root = __dirname
+  const filename = binary ? name : `${name}.node`
+  const build = `${root}/build/Release/${filename}`
+
+  if (existsSync(build)) return build
+
   const folder = findFolder(root)
 
   if (!folder) return
 
-  return findFile(root, folder, name)
+  return findFile(root, folder, name, binary)
 }
 
 function findFolder (root) {
@@ -40,14 +43,16 @@ function findFolder (root) {
     || folders.find(f => f === `${PLATFORM}-${ARCH}`)
 }
 
-function findFile (root, folder, name) {
+function findFile (root, folder, name, binary = false) {
   if (!folder) return
 
   const files = readdirSync(path.join(root, 'prebuilds', folder))
+
+  if (binary) return files.find(f => f === name)
 
   return files.find(f => f === `${name}-${ABI}.node`)
     || files.find(f => f === `${name}-napi.node`)
     || files.find(f => f === `${name}.node`)
 }
 
-module.exports = load
+module.exports = { find, load }

--- a/load.js
+++ b/load.js
@@ -14,12 +14,22 @@ const ABI = process.versions.modules
 const inWebpack = typeof __webpack_require__ === 'function'
 const runtimeRequire = inWebpack ? __non_webpack_require__ : require
 
-function load (name) {
+function maybeLoad (name) {
   try {
-    return runtimeRequire(find(name))
+    return load(name)
   } catch (e) {
     // Not found, skip.
   }
+}
+
+function load (name) {
+  const filename = find(name)
+
+  if (!filename) {
+    throw new Error(`Could not find a ${name} binary for ${PLATFORM}${LIBC}-${ARCH}.`)
+  }
+
+  return runtimeRequire(filename)
 }
 
 function find (name, binary = false) {
@@ -55,4 +65,4 @@ function findFile (root, folder, name, binary = false) {
     || files.find(f => f === `${name}.node`)
 }
 
-module.exports = { find, load }
+module.exports = { find, load, maybeLoad }

--- a/test/pipeline.js
+++ b/test/pipeline.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { pipeline } = require('..')
+const pipeline = require('..').load('pipeline')
 
 if (pipeline) {
   pipeline.init_trace_exporter("127.0.0.1", 8126, 10000, "1.0", "nodejs", "18.0", "v8")

--- a/test/pipeline.js
+++ b/test/pipeline.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const pipeline = require('..').load('pipeline')
+const pipeline = require('..').maybeLoad('pipeline')
 
 if (pipeline) {
   pipeline.init_trace_exporter("127.0.0.1", 8126, 10000, "1.0", "nodejs", "18.0", "v8")


### PR DESCRIPTION
The getters were not really useful additions since they only exposed the bindings directly. There was also no way to find a binary (as opposed to library) file path, and the built-in error handling meant that it's not possible to know what failed in case of errors, so that was moved to the caller as well.