### PR TITLE
add write permission to issues for package-size job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
     needs: build
     permissions:
       issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
   package-size:
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      issues: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
The security settings of the repository have been changed and this permission is no longer granted to all jobs automatically.