### PR TITLE
fix concurrency deadlock in release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - v0.x
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   build:
     uses: Datadog/action-prebuildify/.github/workflows/build.yml@main


### PR DESCRIPTION
The `action-prebuildify` reusable workflow used by the `build` job is already defining concurrency for the entire workflow.