### PR TITLE
v0.2.2 proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/libdatadog",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Node.js binding for libdatadog",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Just a version bump since the fix for macOS ARM64 was actually in `action/prebuildify` which will be used automatically by any new builds.