### PR TITLE
Add APIs for marking the crash as happened during profiler serialization

### DIFF
--- a/crates/crashtracker/src/lib.rs
+++ b/crates/crashtracker/src/lib.rs
@@ -29,3 +29,17 @@ pub fn update_metadata (env: Env, metadata: JsUnknown) -> napi::Result<()> {
 
     Ok(())
 }
+
+#[napi]
+pub fn begin_profiler_serializing (_env: Env) -> napi::Result<()> {
+    let _ = datadog_crashtracker::begin_op(datadog_crashtracker::OpTypes::ProfilerSerializing);
+
+    Ok(())
+}
+
+#[napi]
+pub fn end_profiler_serializing (_env: Env) -> napi::Result<()> {
+    let _ = datadog_crashtracker::end_op(datadog_crashtracker::OpTypes::ProfilerSerializing);
+
+    Ok(())
+}

--- a/test/crashtracker/app.js
+++ b/test/crashtracker/app.js
@@ -38,4 +38,5 @@ crashtracker.init({
   ]
 })
 
+crashtracker.beginProfilerSerializing()
 require('@datadog/segfaultify').segfaultify()

--- a/test/crashtracker/index.js
+++ b/test/crashtracker/index.js
@@ -45,6 +45,13 @@ app.post('/telemetry/proxy/api/v2/apmtelemetry', (req, res) => {
     } else {
       throw new Error('Could not find a stack frame for the crashing function.')
     }
+
+    const tags = req.body.payload[0].tags.split(',')
+    if (tags.includes('profiler_serializing:1')) {
+      console.log('Stack trace was marked as happened during profile serialization.')
+    } else {
+      throw new Error('Stack trace was not marked as happening during profile serialization.')
+    }
   })
 })
 


### PR DESCRIPTION
libdatadog has several [`OpTypes`](https://github.com/DataDog/libdatadog/blob/014b27e731d42445916090b501190fbff0a11de2/crashtracker/src/collector/counters.rs#L21) for annotating crashes with information on what the profiler was doing at the time. `ProfilerSerializing` is relevant to most crashes we observe with Node.js – setting it would add `profiler_serializing:1` tag to the crashes making it easier to filter interesting ones.

https://github.com/DataDog/dd-trace-js/pull/5096 is the dd-trace-js component, and it is dependent on this being released first.

JIRA: [PROF-11108]

[PROF-11108]: https://datadoghq.atlassian.net/browse/PROF-11108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ