### PR TITLE
deps(library_config): bump to v18.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ dependencies = [
 [[package]]
 name = "datadog-library-config"
 version = "0.0.1"
-source = "git+https://github.com/DataDog/libdatadog.git?tag=v16.0.3#ce8c536ddef78a49142fe4a6c77ab0a1263c1018"
+source = "git+https://github.com/DataDog/libdatadog.git?tag=v18.0.0#60583218a8de6768f67d04fcd5bc6443f67f516b"
 dependencies = [
  "anyhow",
  "serde",
@@ -1001,7 +1001,7 @@ dependencies = [
 
 [[package]]
 name = "library-config"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "datadog-library-config",

--- a/crates/library_config/Cargo.toml
+++ b/crates/library_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "library-config"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 [lib]
@@ -8,7 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "1"
-datadog-library-config = { git = "https://github.com/DataDog/libdatadog.git", tag = "v16.0.3" }
+datadog-library-config = { git = "https://github.com/DataDog/libdatadog.git", tag = "v18.0.0" }
 
 wasm-bindgen = "0.2.84"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/library_config/src/lib.rs
+++ b/crates/library_config/src/lib.rs
@@ -120,7 +120,7 @@ impl JsConfigurator {
                 let config_entries: Vec<ConfigEntry> = config
                     .into_iter()
                     .map(|c| ConfigEntry {
-                        name: c.name.to_str().into(),
+                        name: c.name.to_string().into(),
                         value: c.value,
                         source: c.source.to_str().into(),
                         config_id: c.config_id.unwrap_or_default(),


### PR DESCRIPTION
Preparatory changes to facilitate shared in-memory tracing configuration (memfd config) support.