### PR TITLE
feat: add bindings for process/service discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,6 +1347,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-discovery"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "datadog-library-config",
+ "napi",
+ "napi-derive",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 default-members = [
-  "crates/crashtracker"
+  "crates/crashtracker",
+  "crates/process_discovery",
 ]
 members = [
   "crates/*",

--- a/crates/process_discovery/Cargo.toml
+++ b/crates/process_discovery/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "process-discovery"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+anyhow = "1"
+datadog-library-config = { git = "https://github.com/DataDog/libdatadog.git", tag = "v18.1.0" }
+
+napi = { version = "2" }
+napi-derive = { version = "2", default-features = false }

--- a/crates/process_discovery/src/lib.rs
+++ b/crates/process_discovery/src/lib.rs
@@ -1,0 +1,44 @@
+use napi::{Error, Status};
+use napi_derive::napi;
+
+use datadog_library_config::tracer_metadata;
+
+#[napi]
+pub struct NapiAnonymousFileHandle {
+    _internal: tracer_metadata::AnonymousFileHandle,
+}
+
+#[napi]
+impl NapiAnonymousFileHandle {}
+
+#[napi(constructor)]
+pub struct TracerMetadata {
+    pub runtime_id: Option<String>,
+    pub tracer_version: String,
+    pub hostname: String,
+    pub service_name: Option<String>,
+    pub service_env: Option<String>,
+    pub service_version: Option<String>,
+}
+
+#[napi]
+pub fn store_metadata(data: &TracerMetadata) -> napi::Result<NapiAnonymousFileHandle> {
+    let res = tracer_metadata::store_tracer_metadata(&tracer_metadata::TracerMetadata{
+        schema_version: 1,
+        runtime_id: data.runtime_id.clone(),
+        tracer_language: String::from("nodejs"),
+        tracer_version: data.tracer_version.clone(),
+        hostname: data.hostname.clone(),
+        service_name: data.service_name.clone(),
+        service_env: data.service_env.clone(),
+        service_version: data.service_version.clone(),
+    });
+
+    match res {
+        Ok(handle) => Ok(NapiAnonymousFileHandle{ _internal: handle }),
+        Err(e) => {
+            let err_msg = format!("Failed to store the tracer configuration: {:?}", e);
+            Err(Error::new(Status::GenericFailure, err_msg))
+        }
+    }
+}

--- a/test/process_discovery.js
+++ b/test/process_discovery.js
@@ -21,6 +21,20 @@ const cfg_handle = process_discovery.storeMetadata(metadata)
 assert(cfg_handle !== undefined)
 
 if (process.platform === "linux") {
+  const contains_datadog_memfd = (fds) => {
+    for (const fd in fds) {
+      try {
+        const fd_name = fs.readlinkSync(`/proc/${process.pid}/fd/${fd}`);
+        if (fd_name.indexOf("datadog-tracer-info-") !== -1) {
+            return true;
+        }
+      } catch {
+        continue;
+      }
+    }
+    return false
+  };
+
   const fds = fs.readdirSync(`/proc/${process.pid}/fd`)
-  assert.ok(fds.some((fd) => fd.startsWith("datadog-tracer-info-")))
+  assert(contains_datadog_memfd(fds))
 }

--- a/test/process_discovery.js
+++ b/test/process_discovery.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const assert = require('assert');
+const fs = require('fs');
+const process = require('process');
+
+const libdatadog = require('..')
+const process_discovery = libdatadog.load('process_discovery')
+assert(process_discovery !== undefined)
+
+const metadata = new process_discovery.TracerMetadata(
+    "7938685c-19dd-490f-b9b3-8aae4c22f897",
+    "1.0.0",
+    "my_hostname",
+    "my_svc",
+    "my_env",
+    "my_version"
+  )
+
+const cfg_handle = process_discovery.storeMetadata(metadata)
+assert(cfg_handle !== undefined)
+
+if (process.platform === "linux") {
+  const fds = fs.readdirSync(`/proc/${process.pid}/fd`)
+  assert.ok(fds.some((fd) => fd.startsWith("datadog-tracer-info-")))
+}

--- a/test/process_discovery.js
+++ b/test/process_discovery.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const process = require('process');
 
 const libdatadog = require('..')
-const process_discovery = libdatadog.load('process_discovery')
+const process_discovery = libdatadog.load('process-discovery')
 assert(process_discovery !== undefined)
 
 const metadata = new process_discovery.TracerMetadata(


### PR DESCRIPTION
# Description

This PR introduces a new crate, `process_discovery`, which is designed to persist tracer configuration in an in-memory file. This file is seamlessly exposed via `/proc/self/fd` and is interpreted by the Agent Discovery team to identify whether a process is instrumented with a Datadog tracer. 

For further technical details, refer to the [design document](https://docs.google.com/document/d/1kcW6BLdYxXeTSUz31cBqoqfW1Jjs0IDljfKeUfIRQp4/edit?tab=t.0#heading=h.8d3o7vtyu1y1).