### PR TITLE
chore(ci): switch prebuildify back to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           crate: '${{ matrix.crate }}'
 
   build:
-    uses: Datadog/action-prebuildify/.github/workflows/build.yml@d4e89247e6dd34f485c0f92c12f0cc739c2f8c92 # main @ 2026-03-16, last known working version
+    uses: Datadog/action-prebuildify/.github/workflows/build.yml@main
     needs: build-test-wasm
     with:
       package-manager: 'yarn'


### PR DESCRIPTION
reverts changes in a0ac4608846763b3011234784a54f8cd93941f0b / #104 
depends on https://github.com/DataDog/action-prebuildify/pull/100 ✅ 
depends on https://github.com/DataDog/action-prebuildify/pull/101 ✅ 
obsoletes #106 