### PR TITLE
fix(ci): set explicit path for download-artifact in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,10 @@ jobs:
       pkgjson: ${{ steps.pkg.outputs.json }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: prebuilds
+          path: prebuilds
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: '24'


### PR DESCRIPTION
## Summary
- `download-artifact` >= v5.x changed behavior:
  - When downloading all artifacts without specifying a name, it no longer reliably extracts into an artifact-named subdirectory.
  - was upgraded to v8.x in #82
  - see https://github.com/actions/download-artifact/releases/tag/v5.0.0 for breaking changes
  - This caused the `v0.9.1` [release publish job to fail](https://github.com/DataDog/libdatadog-nodejs/actions/runs/23458394049/job/68255005352) with `chmod: cannot access './prebuilds': No such file or directory`.
- Explicitly sets `name: prebuilds` and `path: prebuilds` on the `download-artifact` step to ensure the prebuilds are extracted to the expected location.
- Bumps `download-artifact` from v8.0.0 to v8.0.1 for no real reason.

## Test plan
- [ ] Merge to `v0.x` and verify the release workflow publish job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)