### PR TITLE
chore(DevEx): allow for build on alpine aarch64

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,9 @@ rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]
 
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]
+
+[target.aarch64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static"]
+
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static"]

--- a/.devcontainer/alpine/Dockerfile-alpine
+++ b/.devcontainer/alpine/Dockerfile-alpine
@@ -1,0 +1,2 @@
+FROM node:20-alpine
+RUN apk add --no-cache bash

--- a/.devcontainer/alpine/devcontainer.json
+++ b/.devcontainer/alpine/devcontainer.json
@@ -1,0 +1,32 @@
+{
+    "name": "Node (Alpine ARM64)",
+    "build": {
+        "dockerfile": "Dockerfile-alpine"
+    },
+
+// Ensure ARM64 platform
+    "runArgs": [
+        "--platform=linux/arm64",
+        "--network=host"
+    ],
+    // Persist npm cache
+    "mounts": [
+        {
+            "source": "devcontainer-npm-cache-${devcontainerId}",
+            "target": "/root/.npm",
+            "type": "volume"
+        }
+    ],
+    // Install useful Alpine + Node tooling + Rust + libdatadog build dependencies
+    "onCreateCommand": "apk add --no-cache git bash build-base python3 autoconf automake libtool gcc libc-dev curl musl-dev linux-headers libgcc gcompat && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source ~/.cargo/env && rustup target add aarch64-unknown-linux-gnu",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "dbaeumer.vscode-eslint",
+                "esbenp.prettier-vscode",
+                "ms-vscode.vscode-typescript-next",
+                "ms-azuretools.vscode-docker"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
I wanted to work in a alpine aarch64 dev container while debugging https://github.com/DataDog/libdatadog-nodejs/issues/114, so I added this dev container. 

This is a QoL improvement for future devs also

We need to add this
```
[target.aarch64-unknown-linux-musl]
rustflags = ["-C", "target-feature=-crt-static"]

[target.x86_64-unknown-linux-musl]
rustflags = ["-C", "target-feature=-crt-static"]
```
because 
1. musl targets default to crt-static=enabled (static C runtime)
2. Rust refuses to build cdylib crate types when crt-static is enabled
3. crashtracker crate needs to be cdylib to work as a Node.js .node module


Happy to remove the dev container file and keep the build flag change only, so it works agnostically, no matter if devs spin up the dev container, or devs just work on a aarch64 alpine machine through a different method.