### PR TITLE
perf(capabilities): reduce http request overhead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -81,9 +81,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -124,9 +124,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blazesym"
@@ -134,7 +134,7 @@ version = "0.2.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95824d1dd4f20b4a4dfa63b72954e81914a718357231468180b30314e85057fa"
 dependencies = [
- "cpp_demangle 0.4.5",
+ "cpp_demangle",
  "gimli 0.32.3",
  "libc",
  "memmap2",
@@ -174,9 +174,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cadence"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7aff0c323415907f37007d645d7499c378df47efb3e33ffc1f397fa4e549b2e"
+checksum = "5ca08f6db9f0c963249cf23a27820f9d973d2acaad4d6bfaeb858b58ebd58a6a"
 dependencies = [
  "crossbeam-channel",
 ]
@@ -189,9 +189,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -244,11 +244,12 @@ dependencies = [
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -301,15 +302,6 @@ name = "cpp_demangle"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "cpp_demangle"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
 dependencies = [
  "cfg-if",
 ]
@@ -371,19 +363,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.8.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
-dependencies = [
- "ctor-proc-macro",
- "dtor",
-]
-
-[[package]]
-name = "ctor-proc-macro"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+checksum = "400a21f1014a968ec518c7ccdf9b4a4ed0cac8c56ccb6d604f8b91f00110501e"
 
 [[package]]
 name = "datadog-js-zstd"
@@ -423,21 +405,6 @@ dependencies = [
  "bitflags",
  "objc2",
 ]
-
-[[package]]
-name = "dtor"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
-dependencies = [
- "dtor-proc-macro",
-]
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"
@@ -663,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -720,9 +687,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -733,7 +700,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -741,16 +707,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -808,12 +773,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -845,15 +810,30 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "leb128fmt"
@@ -863,9 +843,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdatadog-nodejs-capabilities"
@@ -877,7 +857,6 @@ dependencies = [
  "http",
  "js-sys",
  "libdd-capabilities",
- "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -885,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-capabilities"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -895,15 +874,13 @@ dependencies = [
 
 [[package]]
 name = "libdd-capabilities-impl"
-version = "0.1.0"
-source = "git+https://github.com/DataDog/libdatadog.git?branch=bengl%2Fcapability-on-change-buffer#8e33f619ccc4136bbb92ac13d241e3cd633b7bfe"
+version = "1.0.0"
 dependencies = [
  "bytes",
  "http",
  "http-body-util",
- "hyper",
  "libdd-capabilities",
- "libdd-common 2.0.1",
+ "libdd-common 4.0.0",
 ]
 
 [[package]]
@@ -941,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-common"
-version = "2.0.1"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -958,7 +935,6 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "libc",
- "libdd-capabilities",
  "nix 0.29.0",
  "pin-project",
  "regex",
@@ -1007,18 +983,21 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline"
-version = "2.0.1"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "arc-swap",
+ "async-trait",
  "bytes",
  "either",
+ "getrandom 0.2.17",
  "http",
  "http-body-util",
  "libdd-capabilities",
- "libdd-common 2.0.1",
- "libdd-ddsketch 1.0.1",
+ "libdd-capabilities-impl",
+ "libdd-common 4.0.0",
  "libdd-dogstatsd-client",
+ "libdd-shared-runtime",
  "libdd-tinybytes",
  "libdd-trace-protobuf",
  "libdd-trace-stats",
@@ -1050,28 +1029,43 @@ dependencies = [
 
 [[package]]
 name = "libdd-dogstatsd-client"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "cadence",
  "http",
- "libdd-common 2.0.1",
+ "libdd-common 4.0.0",
  "serde",
  "tracing",
 ]
 
 [[package]]
 name = "libdd-library-config"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=353134770b312b7ccd2df6afabc253090b948e5f#353134770b312b7ccd2df6afabc253090b948e5f"
+version = "1.1.0"
 dependencies = [
  "anyhow",
+ "libc",
+ "libdd-trace-protobuf",
  "memfd",
+ "prost",
  "rand",
  "rmp",
  "rmp-serde",
  "serde",
  "serde_yaml",
+]
+
+[[package]]
+name = "libdd-shared-runtime"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "futures",
+ "libdd-capabilities",
+ "libdd-common 4.0.0",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1109,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-normalization"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf",
@@ -1117,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-protobuf"
-version = "2.0.0"
+version = "3.0.1"
 dependencies = [
  "prost",
  "serde",
@@ -1126,27 +1120,42 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-stats"
-version = "1.0.3"
+version = "2.0.0"
 dependencies = [
+ "anyhow",
+ "async-trait",
  "hashbrown 0.15.5",
+ "http",
+ "libdd-capabilities",
+ "libdd-capabilities-impl",
+ "libdd-common 4.0.0",
  "libdd-ddsketch 1.0.1",
+ "libdd-shared-runtime",
  "libdd-trace-protobuf",
  "libdd-trace-utils",
+ "rmp-serde",
+ "serde",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
 name = "libdd-trace-utils"
-version = "2.0.2"
+version = "3.0.1"
 dependencies = [
  "anyhow",
+ "base64",
  "bytes",
  "futures",
+ "getrandom 0.2.17",
  "http",
  "http-body",
  "http-body-util",
  "indexmap",
  "libdd-capabilities",
- "libdd-common 2.0.1",
+ "libdd-capabilities-impl",
+ "libdd-common 4.0.0",
  "libdd-tinybytes",
  "libdd-trace-normalization",
  "libdd-trace-protobuf",
@@ -1155,7 +1164,6 @@ dependencies = [
  "rmp",
  "rmp-serde",
  "rmpv",
- "rustc-hash",
  "serde",
  "serde_json",
  "tokio",
@@ -1305,12 +1313,12 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.8.4"
+version = "3.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7848c221fb7bb789e02f01875287ebb1e078b92a6566a34de01ef8806e7c2b"
+checksum = "8e55037284865448ecf329baa86a4d05401f647ebde99f5747b640d32c2c5226"
 dependencies = [
  "bitflags",
- "ctor 0.8.0",
+ "ctor 0.11.1",
  "futures",
  "napi-build",
  "napi-sys 3.2.1",
@@ -1340,12 +1348,12 @@ dependencies = [
 
 [[package]]
 name = "napi-derive"
-version = "3.5.3"
+version = "3.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60867ff9a6f76e82350e0c3420cb0736f5866091b61d7d8a024baa54b0ec17dd"
+checksum = "a4ba740fe4c9524d86fd90798fd8ccdb23402b3eef7e7c30897a8a369b529fcf"
 dependencies = [
  "convert_case 0.11.0",
- "napi-derive-backend 5.0.2",
+ "napi-derive-backend 5.0.4",
  "proc-macro2",
  "quote",
  "syn",
@@ -1368,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "5.0.2"
+version = "5.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0864cf6a82e2cfb69067374b64c9253d7e910e5b34db833ed7495dda56ccb18"
+checksum = "0d5af30503edf933ce7377cf6d4c877a62b0f1107ea05585f1b5e430e88d5baf"
 dependencies = [
  "convert_case 0.11.0",
  "proc-macro2",
@@ -1639,9 +1647,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
-version = "0.2.1"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "os_info"
@@ -1696,12 +1704,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pipeline"
 version = "0.1.0"
 dependencies = [
@@ -1746,9 +1748,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -1793,8 +1795,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "libdd-library-config",
- "napi 3.8.4",
- "napi-derive 3.5.3",
+ "napi 3.8.6",
+ "napi-derive 3.5.5",
 ]
 
 [[package]]
@@ -1843,9 +1845,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1969,9 +1971,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -1984,9 +1986,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -1996,18 +1998,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2094,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2251,9 +2253,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"
-version = "12.17.3"
+version = "12.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ca086c1eb5c7ee74b151ba83c6487d5d33f8c08ad991b86f3f58f6629e68d5"
+checksum = "332615d90111d8eeaf86a84dc9bbe9f65d0d8c5cf11b4caccedc37754eb0dcfd"
 dependencies = [
  "debugid",
  "memmap2",
@@ -2263,11 +2265,11 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.17.3"
+version = "12.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa911a28a62823aaf2cc2e074212492a3ee69d0d926cc8f5b12b4a108ff5c0c"
+checksum = "912017718eb4d21930546245af9a3475c9dccf15675a5c215664e76621afc471"
 dependencies = [
- "cpp_demangle 0.5.1",
+ "cpp_demangle",
  "msvc-demangler",
  "rustc-demangle",
  "symbolic-common",
@@ -2316,9 +2318,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -2331,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2412,9 +2414,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -2448,9 +2450,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -2491,11 +2493,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -2504,14 +2506,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2522,9 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2532,9 +2534,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2542,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2555,18 +2557,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.65"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1138411301a026d6662dc44e7076a74dbaa76a369312275eea5dee4d7dc68c7c"
+checksum = "29826f9d9ecaa314c480d376b276d1c790e6cb6a4681fab8532da69cbabf977d"
 dependencies = [
  "async-trait",
  "cast",
@@ -2586,9 +2588,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.65"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186ddfe8383ba7ae7927bae3bb7343fd1f03ba2dbaf1474410f0d831131c269b"
+checksum = "c610311887f9e6599a546d278d12d69dfd3a3e92639b2129e4b11ad6cf1961d6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2597,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.115"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f032e076ceb8d36d5921c6cef5bf447f2ca2bbd5439ce1683d68d1c99cc2be16"
+checksum = "60238e5b4b1b295701d6f9a66d2a126fe19990348f5fb9dae3b623a370119d94"
 
 [[package]]
 name = "wasm-encoder"
@@ -3013,6 +3015,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,21 +13,15 @@ codegen-units = 1
 lto = true
 opt-level = "z"
 panic = "abort"
-strip = "none"
-debug = 1
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[patch."https://github.com/DataDog/libdatadog.git"]
-libdd-trace-utils = { path = "/Users/bryan.english/libdatadog-local/libdd-trace-utils" }
-libdd-capabilities = { path = "/Users/bryan.english/libdatadog-local/libdd-capabilities" }
-libdd-data-pipeline = { path = "/Users/bryan.english/libdatadog-local/libdd-data-pipeline" }
-libdd-trace-protobuf = { path = "/Users/bryan.english/libdatadog-local/libdd-trace-protobuf" }
-libdd-trace-stats = { path = "/Users/bryan.english/libdatadog-local/libdd-trace-stats" }
-libdd-common = { path = "/Users/bryan.english/libdatadog-local/libdd-common" }
-libdd-tinybytes = { path = "/Users/bryan.english/libdatadog-local/libdd-tinybytes" }
-libdd-trace-normalization = { path = "/Users/bryan.english/libdatadog-local/libdd-trace-normalization" }
-libdd-dogstatsd-client = { path = "/Users/bryan.english/libdatadog-local/libdd-dogstatsd-client" }
-libdd-ddsketch = { path = "/Users/bryan.english/libdatadog-local/libdd-ddsketch" }
+# strip = "none"
+debug = true
 
 
+[patch.'https://github.com/DataDog/libdatadog.git']
+libdd-capabilities = { path = "../libdatadog_node_native_spans_worktree/libdd-capabilities" }
+libdd-capabilities-impl = { path = "../libdatadog_node_native_spans_worktree/libdd-capabilities-impl" }
+libdd-data-pipeline = { path = "../libdatadog_node_native_spans_worktree/libdd-data-pipeline" }
+libdd-trace-utils = {  path = "../libdatadog_node_native_spans_worktree/libdd-trace-utils" }
+libdd-trace-stats = {  path = "../libdatadog_node_native_spans_worktree/libdd-trace-stats" }
+libdd-trace-protobuf = {  path = "../libdatadog_node_native_spans_worktree/libdd-trace-protobuf" }
+libdd-library-config = {  path = "../libdatadog_node_native_spans_worktree/libdd-library-config" }

--- a/change-buffer-build.sh
+++ b/change-buffer-build.sh
@@ -1,0 +1,4 @@
+rm -f Cargo.lock
+rm -rf prebuilds/*
+npm run build-wasm
+npx napi build --platform -p pipeline-native -o prebuilds/fastline --release

--- a/crates/capabilities/Cargo.toml
+++ b/crates/capabilities/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["rlib"]
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
-serde_json = "1.0"
 http = "1"
 bytes = "1.4"
 futures-core = "0.3"

--- a/crates/capabilities/src/http.rs
+++ b/crates/capabilities/src/http.rs
@@ -6,31 +6,43 @@
 //! The JS transport is imported via `wasm_bindgen(module = ...)` from
 //! `http_transport.js`, which ships alongside the wasm output.
 
-use std::collections::HashMap;
 use std::future::Future;
+use std::io::Write as _;
+use std::sync::LazyLock;
 
 use bytes::Bytes;
-use js_sys;
+use http::{HeaderMap, HeaderName, HeaderValue};
+use js_sys::{self, Array, JsString, Number, Uint8Array};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
 use libdd_capabilities::http::{HttpClientTrait, HttpError};
 use libdd_capabilities::maybe_send::MaybeSend;
 
+static WASM_MEMORY: LazyLock<JsValue> = LazyLock::new(|| wasm_bindgen::memory());
+
 #[wasm_bindgen(module = "/src/http_transport.js")]
 extern "C" {
     #[wasm_bindgen(js_name = "httpRequest")]
     fn http_request(
-        method: &str,
-        url: &str,
-        headers_json: &str,
-        body: &[u8],
+        host: &str,
+        port: u16,
+        is_https: bool,
+        head_ptr: *const u8,
+        head_len: u32,
+        body_ptr: *const u8,
+        body_len: u32,
+        wasm_memory: &JsValue,
     ) -> js_sys::Promise;
+
+    #[wasm_bindgen(js_name = "setStorage")]
+    pub fn set_storage(new_storage: &JsValue);
 }
 
 /// Wasm [`HttpClientTrait`] implementation that delegates to Node.js HTTP.
 ///
 /// Named `DefaultHttpClient` to match the native version's public API.
+#[derive(Debug, Clone)]
 pub struct DefaultHttpClient;
 
 impl HttpClientTrait for DefaultHttpClient {
@@ -44,77 +56,118 @@ impl HttpClientTrait for DefaultHttpClient {
         req: http::Request<Bytes>,
     ) -> impl Future<Output = Result<http::Response<Bytes>, HttpError>> + MaybeSend {
         async move {
-            let method = req.method().as_str().to_owned();
-            let url = req.uri().to_string();
-            let headers_json = serialize_headers(req.headers())?;
+            let scheme = req.uri().scheme_str().unwrap_or("http");
+            let is_https = scheme == "https";
+            let host = req
+                .uri()
+                .host()
+                .ok_or_else(|| HttpError::InvalidRequest(anyhow::anyhow!("missing host in URI")))?
+                .to_owned();
+            let port = req
+                .uri()
+                .port_u16()
+                .unwrap_or(if is_https { 443 } else { 80 });
+
+            let head = serialize_request_head(&req, &host, port, is_https)?;
             let body = req.into_body();
 
-            let result = JsFuture::from(http_request(&method, &url, &headers_json, &body))
-                .await
-                .map_err(|e| HttpError::Network(anyhow::anyhow!("{:?}", e)))?;
+            let result = JsFuture::from(http_request(
+                &host,
+                port,
+                is_https,
+                head.as_ptr(),
+                head.len() as u32,
+                body.as_ptr(),
+                body.len() as u32,
+                WASM_MEMORY.as_ref(),
+            ))
+            .await
+            .map_err(|e| HttpError::Network(anyhow::anyhow!("{:?}", e)))?;
 
-            let status = js_sys::Reflect::get(&result, &JsValue::from_str("status"))
-                .map_err(|_| HttpError::Other(anyhow::anyhow!("missing status in response")))?
+            let result: js_sys::ArrayTuple<(Number, Array<JsString>, Uint8Array)> =
+                js_sys::ArrayTuple::unchecked_from_js(result);
+
+            let status = result
+                .get0()
                 .as_f64()
                 .ok_or_else(|| HttpError::Other(anyhow::anyhow!("status is not a number")))?
                 as u16;
 
-            let headers = parse_response_headers(&result)?;
+            let headers = parse_response_headers(result.get1())?;
 
-            let body_js = js_sys::Reflect::get(&result, &JsValue::from_str("body"))
-                .map_err(|_| HttpError::Other(anyhow::anyhow!("missing body in response")))?;
-
-            let body = if body_js.is_undefined() || body_js.is_null() {
-                Bytes::new()
-            } else {
-                Bytes::from(js_sys::Uint8Array::new(&body_js).to_vec())
-            };
+            let body = Bytes::from(result.get2().to_vec());
 
             let mut builder = http::Response::builder().status(status);
-            for (name, value) in &headers {
-                builder = builder.header(name.as_str(), value.as_str());
-            }
-            builder
-                .body(body)
-                .map_err(|e| HttpError::Other(e.into()))
+            *builder.headers_mut().unwrap() = headers;
+            builder.body(body).map_err(|e| HttpError::Other(e.into()))
         }
     }
-
 }
 
 /// Parse response headers from a JS object `{ "header-name": "value", ... }`.
 ///
 /// Node.js `res.headers` returns lowercased header names with string values.
-fn parse_response_headers(result: &JsValue) -> Result<Vec<(String, String)>, HttpError> {
-    let headers_js = js_sys::Reflect::get(result, &JsValue::from_str("headers"))
-        .map_err(|_| HttpError::Other(anyhow::anyhow!("missing headers in response")))?;
-
-    if headers_js.is_undefined() || headers_js.is_null() {
-        return Ok(Vec::new());
-    }
-
-    let entries = js_sys::Object::entries(&js_sys::Object::unchecked_from_js(headers_js));
-    let mut headers = Vec::with_capacity(entries.length() as usize);
-    for i in 0..entries.length() {
-        let entry = js_sys::Array::from(&entries.get(i));
-        if let (Some(key), Some(value)) = (entry.get(0).as_string(), entry.get(1).as_string()) {
-            headers.push((key, value));
+fn parse_response_headers(header_js: Array<JsString>) -> Result<HeaderMap, HttpError> {
+    let len = header_js.length() as usize;
+    let mut headers = HeaderMap::with_capacity(len / 2);
+    for i in 0..(len / 2) {
+        let key = header_js.get((i * 2) as u32).as_string();
+        let val = header_js.get((i * 2 + 1) as u32).as_string();
+        if let (Some(key), Some(val)) = (key, val) {
+            headers.insert(
+                HeaderName::from_bytes(key.as_bytes()).unwrap(),
+                HeaderValue::from_maybe_shared(Bytes::from(val)).unwrap(),
+            );
         }
     }
     Ok(headers)
 }
 
-fn serialize_headers(headers: &http::HeaderMap) -> Result<String, HttpError> {
-    let mut map: HashMap<&str, Vec<&str>> = HashMap::new();
-    for (name, value) in headers.iter() {
-        map.entry(name.as_str())
-            .or_default()
-            .push(value.to_str().unwrap_or(""));
+/// Serialize the full HTTP/1.1 request head (request line + Host + Content-Length
+/// + user headers + terminating CRLF) into a contiguous byte buffer.
+///
+/// The buffer is handed to JS by pointer; JS assigns it to
+/// `req._header`, bypassing Node's `_storeHeader` serialization.
+fn serialize_request_head(
+    req: &http::Request<Bytes>,
+    host: &str,
+    port: u16,
+    is_https: bool,
+) -> Result<Vec<u8>, HttpError> {
+    let method = req.method().as_str();
+    let path_and_query = req
+        .uri()
+        .path_and_query()
+        .map(|pq| pq.as_str())
+        .unwrap_or("/");
+    let body_len = req.body().len();
+    let headers = req.headers();
+
+    let mut buf = Vec::with_capacity(256 + headers.len() * 64);
+
+    buf.extend_from_slice(method.as_bytes());
+    buf.push(b' ');
+    buf.extend_from_slice(path_and_query.as_bytes());
+    buf.extend_from_slice(b" HTTP/1.1\r\n");
+
+    buf.extend_from_slice(b"Host: ");
+    buf.extend_from_slice(host.as_bytes());
+    let default_port = if is_https { 443 } else { 80 };
+    if port != default_port {
+        write!(&mut buf, ":{port}").map_err(|e| HttpError::Other(e.into()))?;
     }
-    let flat: HashMap<&str, String> = map
-        .into_iter()
-        .map(|(k, v)| (k, v.join(", ")))
-        .collect();
-    serde_json::to_string(&flat)
-        .map_err(|e| HttpError::InvalidRequest(e.into()))
+    buf.extend_from_slice(b"\r\n");
+
+    write!(&mut buf, "Content-Length: {body_len}\r\n").map_err(|e| HttpError::Other(e.into()))?;
+
+    for (name, value) in headers.iter() {
+        buf.extend_from_slice(name.as_str().as_bytes());
+        buf.extend_from_slice(b": ");
+        buf.extend_from_slice(value.as_bytes());
+        buf.extend_from_slice(b"\r\n");
+    }
+
+    buf.extend_from_slice(b"\r\n");
+
+    Ok(buf)
 }

--- a/crates/capabilities/src/http_transport.js
+++ b/crates/capabilities/src/http_transport.js
@@ -1,35 +1,67 @@
 const http = require('http');
 const https = require('https');
 
-module.exports.httpRequest = function (method, url, headersJson, body) {
-  const headers = JSON.parse(headersJson || '{}');
-  headers['Content-Length'] = body.length;
-  const parsed = new URL(url);
-  const transport = parsed.protocol === 'https:' ? https : http;
+let storage = (f) => f();
 
-  return new Promise((resolve, reject) => {
-    const req = transport.request(
-      {
-        hostname: parsed.hostname,
-        port: parsed.port,
-        path: parsed.pathname + parsed.search,
-        method,
-        headers,
-      },
-      (res) => {
-        const chunks = [];
-        res.on('data', (chunk) => chunks.push(chunk));
-        res.on('end', () => {
-          resolve({
-            status: res.statusCode,
-            headers: res.headers,
-            body: new Uint8Array(Buffer.concat(chunks)),
+module.exports.setStorage = function (new_storage) {
+  storage = new_storage;
+}
+
+module.exports.httpRequest = function (host, port, isHttps, head_ptr, head_len, body_ptr, body_len, wasm_memory) {
+  const transport = isHttps ? https : http;
+
+  function isDetachedBufferError(err) {
+    return err instanceof TypeError && /detached/i.test(err.message);
+  }
+
+  function attempt() {
+    return new Promise((resolve, reject) => {
+      storage(() => {
+        // wasm_memory.buffer is replaced each time WebAssembly.Memory grows, so
+        // the views must be recreated on every attempt against the current buffer.
+        const headView = new Uint8Array(wasm_memory.buffer, head_ptr, head_len);
+        const bodyView = new Uint8Array(wasm_memory.buffer, body_ptr, body_len);
+
+        // host/port drive socket selection; method/path/headers are placeholders
+        // because we replace the rendered head below.
+        const req = transport.request({ host, port, method: 'POST', path: '/' }, (res) => {
+          const chunks = [];
+          res.on('data', (chunk) => chunks.push(chunk));
+          res.on('end', () => {
+            const body = Buffer.concat(chunks)
+            resolve([
+              res.statusCode,
+              res.rawHeaders,
+              new Uint8Array(body.buffer),
+            ]);
           });
         });
+        req.on('error', reject);
+
+        // Bypass Node's headers: the Rust side has already produced the full
+        // request head in HTTP/1.1 wire format. Setting _header before write()
+        // makes write/end skip _implicitHeader and _send prepends our bytes.
+        
+        try {
+          req._header = Buffer.from(headView);
+          req.write(bodyView);
+          req.end();
+        } catch (err) {
+          reject(err);
+        }
+      })
+    });
+  }
+
+  function attemptWithRetry() {
+    return attempt().catch((err) => {
+      process.stderr.write("httpRequest error: " + err + "\n")
+      if (isDetachedBufferError(err)) {
+        return attemptWithRetry();
       }
-    );
-    req.on('error', reject);
-    req.write(body);
-    req.end();
-  });
+      throw err;
+    });
+  }
+
+  return attemptWithRetry();
 };

--- a/crates/pipeline/src/lib.rs
+++ b/crates/pipeline/src/lib.rs
@@ -83,7 +83,8 @@ impl WasmSpanState {
             .set_tracer_version(tracer_version)
             .set_language(lang)
             .set_language_version(lang_version)
-            .set_language_interpreter(lang_interpreter);
+            .set_language_interpreter(lang_interpreter)
+            .enable_agent_rates_payload_version();
 
         let mut change_queue = vec![0u8; change_queue_size as usize];
         let change_buffer =
@@ -474,4 +475,9 @@ pub fn get_op_codes() -> JsValue {
             .unwrap();
     }
     obj.into()
+}
+
+#[wasm_bindgen(js_name = "setStorage")]
+pub fn set_storage(new_storage: &JsValue) {
+    libdatadog_nodejs_capabilities::http::set_storage(new_storage);
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-debug": "mkdir -p target && yarn -s cargo-build > ./target/out.ndjson && yarn -s copy-artifacts",
     "build-release": "mkdir -p target && yarn -s cargo-build-release > ./target/out.ndjson && yarn -s copy-artifacts",
     "build-all": "mkdir -p target && yarn -s cargo-build -- --workspace > ./target/out.ndjson && yarn -s copy-artifacts && yarn -s build-wasm",
-    "build-wasm": "yarn -s install-wasm-pack && node scripts/build-wasm.js library_config && node scripts/build-wasm.js datadog-js-zstd && node scripts/build-wasm.js trace_exporter && node scripts/build-wasm.js pipeline",
+    "build-wasm": "node scripts/build-wasm.js library_config && node scripts/build-wasm.js datadog-js-zstd && node scripts/build-wasm.js trace_exporter && node scripts/build-wasm.js pipeline",
     "cargo-build-release": "yarn -s cargo-build -- --release",
     "cargo-build": "cargo build --message-format=json-render-diagnostics",
     "copy-artifacts": "node ./scripts/copy-artifacts",
@@ -27,5 +27,8 @@
   "homepage": "https://github.com/DataDog/libdatadog-nodejs#readme",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@napi-rs/cli": "^3.6.0"
   }
 }


### PR DESCRIPTION
This is done in multiple ways:

* Do not copy the request body or headers. These are passed to JS as
    pointers into the WASM memory. If they become detached during the
    request, it is retried
* Allow separating the request from the async local storage
    in order to no instrument it
* Enabled agent rates header, reducing agent response size if unchanged
* More efficient response header parsing, reducing copies
