### PR TITLE
feat(ci): build and ship Windows x64 prebuilds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       cache: false
       min-node-version: 18
       rust: true
-      only: darwin-arm64,darwin-x64,linux-arm64,linux-x64
+      only: darwin-arm64,darwin-x64,linux-arm64,linux-x64,windows-x64
       # Need this, now that libdatadog packages libunwind as a submodule
       prebuild: '(command -v apk >/dev/null && apk add autoconf automake libtool) || (command -v apt-get >/dev/null && apt-get update && apt-get install -y autoconf automake libtool) || true'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       cache: false
       min-node-version: 18
       rust: true
-      only: darwin-arm64,darwin-x64,linux-arm64,linux-x64
+      only: darwin-arm64,darwin-x64,linux-arm64,linux-x64,windows-x64
 
   publish:
     runs-on: ubuntu-latest

--- a/load.js
+++ b/load.js
@@ -10,6 +10,7 @@ const PLATFORM = os.platform()
 const ARCH = process.arch
 const LIBC = PLATFORM === 'linux' ? (existsSync('/etc/alpine-release') ? 'musl' : 'glibc') : ''
 const ABI = process.versions.modules
+const EXE_SUFFIX = PLATFORM === 'win32' ? '.exe' : ''
 
 const inWebpack = typeof __webpack_require__ === 'function'
 const runtimeRequire = inWebpack ? __non_webpack_require__ : require
@@ -52,7 +53,7 @@ function find (name, binary = false) {
   // Only apply hyphen-to-underscore conversion for .node libraries, not binaries
   const transformedName = binary ? name : name.replaceAll('-', '_')
 
-  const filename = binary ? transformedName : `${transformedName}.node`
+  const filename = binary ? `${transformedName}${EXE_SUFFIX}` : `${transformedName}.node`
   const build = `${root}/build/Release/${filename}`
 
   if (existsSync(build)) return build
@@ -84,7 +85,7 @@ function findFolder (root) {
 function findFile (root, name, binary = false) {
   const files = readdirSync(root)
 
-  if (binary) return files.find(f => f === name)
+  if (binary) return files.find(f => f === `${name}${EXE_SUFFIX}`)
 
   return files.find(f => f === `${name}-${ABI}.node`)
     || files.find(f => f === `${name}-napi.node`)

--- a/scripts/copy-artifacts.js
+++ b/scripts/copy-artifacts.js
@@ -13,13 +13,15 @@ const lineReader = readline.createInterface({
   input: fs.createReadStream(outPath),
 })
 
+const exeSuffix = process.platform === 'win32' ? '.exe' : ''
+
 lineReader.on('line', function (line) {
   const { filenames, reason, target } = JSON.parse(line)
 
   if (reason !== 'compiler-artifact') return
   if (!target.src_path.startsWith(cratesPath)) return
 
-  const filename = target.kind[0] === 'bin' ? target.name : `${target.name}.node`
+  const filename = target.kind[0] === 'bin' ? `${target.name}${exeSuffix}` : `${target.name}.node`
   const filePath = path.join(buildPath, filename)
 
   fs.mkdirSync(buildPath, { recursive: true })


### PR DESCRIPTION
### What

Adds `win32-x64` to the `action-prebuildify` `only:` filter on both `build.yml` and `release.yml`, plus the two supporting fixes needed for the Windows artifact pipeline:

- **`scripts/copy-artifacts.js`** preserves `.exe` on Windows when copying Rust `[[bin]]` outputs (e.g. `crashtracker-receiver`). Without this, the file gets copied without extension and can't be `CreateProcess`'d.
- **`load.js`** appends `.exe` on Windows when looking up binaries (both in `build/Release` and in `prebuilds/win32-x64`), so `libdatadog.find('crashtracker-receiver', true)` resolves to the right file.

### Why

dd-trace-js's crashtracker is currently a silent no-op on Windows because `@datadog/libdatadog` ships no Windows prebuild, so `libdatadog.load('crashtracker')` throws and the wrapper falls back to the noop crashtracker. As a result, repeated Windows-only `STATUS_STACK_BUFFER_OVERRUN` (`0xC0000409`) crashes in the dd-trace-js profiler tests produce no crash reports — see PROF-14469.

Upstream `libdd-crashtracker` (libdatadog v29) already supports Windows: its `Cargo.toml` has a `[target.'cfg(windows)'.dependencies] windows = "0.59.0"` block and the default features include `collector_windows` (in-process collector). Our `crates/crashtracker/src/bin/receiver.rs` already has a `#[cfg(not(unix))] fn main(){}` stub.

### Test plan

This PR exists primarily to see whether the Windows runner build succeeds. Most likely point of failure is `aws-lc-sys` (pulled in by `rustls` with the `aws-lc-rs` provider). If that breaks on Windows, simplest follow-up is switching the Windows build to the `ring` provider, or making `aws-lc-rs` Unix-only.

### Related

- PROF-14469 — Windows worker crashes (STATUS_STACK_BUFFER_OVERRUN) on profiler unit-test process exit