### PR TITLE
process_discovery: expose threadlocal_attribute_keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,17 +811,17 @@ dependencies = [
 
 [[package]]
 name = "libdd-library-config"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?tag=v29.0.0#001bd56fcbba34fa4ec3f9798a6c4fbcddeffa40"
+version = "2.0.0"
+source = "git+https://github.com/DataDog/libdatadog.git?tag=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "anyhow",
+ "libc",
  "libdd-trace-protobuf",
  "memfd",
  "prost",
  "rand",
  "rmp",
  "rmp-serde",
- "rustix",
  "serde",
  "serde_yaml",
 ]
@@ -883,8 +883,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-protobuf"
-version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog.git?tag=v29.0.0#001bd56fcbba34fa4ec3f9798a6c4fbcddeffa40"
+version = "3.0.2"
+source = "git+https://github.com/DataDog/libdatadog.git?tag=v35.0.0#aa78483fba211c72ca3759c76318895f45e0184b"
 dependencies = [
  "prost",
  "serde",

--- a/crates/process_discovery/Cargo.toml
+++ b/crates/process_discovery/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "1"
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog.git", tag = "v29.0.0" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog.git", tag = "v35.0.0", features = ["otel-thread-ctx"] }
 
 napi = { version = "2" }
 napi-derive = { version = "2", default-features = false }

--- a/crates/process_discovery/src/lib.rs
+++ b/crates/process_discovery/src/lib.rs
@@ -21,6 +21,16 @@ pub struct TracerMetadata {
     pub service_version: Option<String>,
     pub process_tags: Option<String>,
     pub container_id: Option<String>,
+    /// Ordered list of attribute key names for thread-level OTEP-4947
+    /// context records. Key indices on the wire index into this list.
+    /// libdatadog's OTel process-context conversion prepends the
+    /// implicit `datadog.local_root_span_id` entry at wire index 0, so
+    /// callers should only set their additional keys here — entry 0 in
+    /// this list corresponds to wire key index 1.
+    ///
+    /// `null`/omitted (the default) disables the thread-context-related
+    /// attributes in the OTel process context entirely.
+    pub threadlocal_attribute_keys: Option<Vec<String>>,
 }
 
 #[napi]
@@ -36,6 +46,7 @@ pub fn store_metadata(data: &TracerMetadata) -> napi::Result<NapiAnonymousFileHa
         service_version: data.service_version.clone(),
         process_tags: data.process_tags.clone(),
         container_id: data.container_id.clone(),
+        threadlocal_attribute_keys: data.threadlocal_attribute_keys.clone(),
     });
 
     match res {

--- a/test/process-discovery.js
+++ b/test/process-discovery.js
@@ -22,6 +22,27 @@ const metadata = new process_discovery.TracerMetadata(
 const cfg_handle = process_discovery.storeMetadata(metadata)
 assert(cfg_handle !== undefined)
 
+// Same shape, plus a thread-local attribute key map (OTEP-4947). libdatadog
+// implicitly prepends `datadog.local_root_span_id` at wire index 0; entries
+// here start at wire index 1.
+const metadata_with_threadlocal = new process_discovery.TracerMetadata(
+  '7938685c-19dd-490f-b9b3-8aae4c22f898',
+  '1.0.0',
+  'my_hostname',
+  'my_svc',
+  'my_env',
+  'my_version',
+  undefined,
+  undefined,
+  ['endpoint', 'http.status'],
+)
+assert.deepStrictEqual(
+  metadata_with_threadlocal.threadlocalAttributeKeys,
+  ['endpoint', 'http.status'],
+)
+const cfg_handle_threadlocal = process_discovery.storeMetadata(metadata_with_threadlocal)
+assert(cfg_handle_threadlocal !== undefined)
+
 if (process.platform === 'linux') {
   const contains_datadog_memfd = (fds) => {
     for (const fd in fds) {


### PR DESCRIPTION
## Summary

Adds an optional `threadlocal_attribute_keys: Option<Vec<String>>` field to the NAPI `TracerMetadata` and forwards it to libdatadog's `tracer_metadata::TracerMetadata`. When set, libdatadog's `to_otel_process_ctx` injects into the OTel process context:

```
threadlocal.schema_version    = "tlsdesc_v1_dev"
threadlocal.attribute_key_map = ["datadog.local_root_span_id",
                                  ...threadlocal_attribute_keys]
```

— giving an out-of-process reader the name table for the uint8 key indices that OTEP-4947 thread-context records carry on the wire. The implicit `datadog.local_root_span_id` key is prepended by libdatadog itself; callers only supply their *additional* keys (entry 0 in this list = wire key index 1).

## Motivation

A Node.js OTEP-4947 thread-context writer (currently in development in [DataDog/pprof-nodejs#347](https://github.com/DataDog/pprof-nodejs/pull/347), to be integrated into dd-trace-js) needs to publish its attribute key list as part of the OTel process context so that an out-of-process eBPF reader can decode the on-wire `key_index` bytes back to attribute names. This change is the dd-trace-js-facing piece of that plumbing.

## Implementation notes

- The field is gated behind libdatadog's `otel-thread-ctx` Cargo feature, which arrived after v29.0.0. The `libdd-library-config` dep is bumped from v29.0.0 → v35.0.0 (matching the version already pinned by the crashtracker crate in this workspace) and the feature is enabled.
- Existing 8-arg constructor calls keep working because the new field is optional.
- The test exercises both the absent and present forms.

## Test plan

- [x] `yarn build-debug` succeeds with the bumped dependency
- [x] `node test/process-discovery.js` passes (both the existing positional call and the new threadlocal-keys variant)
- [x] `yarn lint test/process-discovery.js` clean
- [ ] CI verifies the same on all supported Node versions / platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)