### PR TITLE
fix: release tag push

### DIFF
--- a/.github/chainguard/self.github.release.push-tags.sts.yaml
+++ b/.github/chainguard/self.github.release.push-tags.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/libdatadog-nodejs:environment:npm
+
+claim_pattern:
+  event_name: push
+  job_workflow_ref: DataDog/libdatadog-nodejs/\.github/workflows/release\.yml@refs/heads/v[0-9]+\.x
+  ref: refs/heads/v[0-9]+\.x
+  repository: DataDog/libdatadog-nodejs
+
+permissions:
+  contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,18 @@ jobs:
     environment: npm
     permissions:
       id-token: write  # Required for OIDC
-      contents: write
+      contents: read
     outputs:
       pkgjson: ${{ steps.pkg.outputs.json }}
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/libdatadog-nodejs
+          policy: self.github.release.push-tags
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false # drop GITHUB_TOKEN so the dd-octo-sts token is used for the tag push
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: prebuilds
@@ -57,4 +64,4 @@ jobs:
           echo "json=$content" >> $GITHUB_OUTPUT
       - run: |
           git tag v${{ fromJson(steps.pkg.outputs.json).version }}
-          git push origin v${{ fromJson(steps.pkg.outputs.json).version }}
+          git push https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com/${{ github.repository }}.git v${{ fromJson(steps.pkg.outputs.json).version }}


### PR DESCRIPTION
The release workflow's tag push was rejected by the tag ruleset because `actions/checkout` persisted GITHUB_TOKEN credentials, which took precedence over the `dd-octo-sts` token in the explicit push URL.

## Changes

- Add `DataDog/dd-octo-sts-action` step to obtain a token with tag-push permission
- Add `.github/chainguard/self.github.release.push-tags.sts.yaml` policy file
- Set `persist-credentials: false` on checkout so the GITHUB_TOKEN doesn't shadow the octo-sts token
- Downgrade `contents` permission from `write` to `read`

Mirrors the fix applied in DataDog/pprof-format#65 and DataDog/pprof-nodejs@1417470e2c51046d4e7ff48ca6f10032ff91816f