### PR TITLE
PROF-15218: Update build-test-wasm composite action to Node.js 24 versions

### DIFF
--- a/.github/actions/build-test-wasm/action.yaml
+++ b/.github/actions/build-test-wasm/action.yaml
@@ -7,10 +7,10 @@ inputs:
 runs:
   using: 'composite'
   steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       - run: yarn install
         shell: bash
       - name: Install wasm-pack
@@ -24,7 +24,7 @@ runs:
       - name: Test WASM
         run: node test-wasm.js ${{ inputs.crate }}
         shell: bash
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: prebuilds-wasm-${{ inputs.crate }}
           if-no-files-found: ignore


### PR DESCRIPTION
The build-test-wasm composite action lagged on v4 / Node 20-era actions while the rest of the repo is current. This brings it in line with the repo's existing pins:

- actions/checkout v6.0.2
- actions/download-artifact v8.0.1
- actions/setup-node v6.3.0
- actions/upload-artifact v7.0.1

Only the version refs are changed; the download-artifact and upload-artifact `with:` blocks are left unchanged.