### PR TITLE
fix(pipeline): set exporter runtime-id from the tracer

### DIFF
--- a/crates/pipeline/src/lib.rs
+++ b/crates/pipeline/src/lib.rs
@@ -248,6 +248,7 @@ impl WasmSpanState {
             .set_env(env)
             .set_hostname(hostname)
             .set_app_version(app_version)
+            .set_runtime_id(runtime_id)
             .enable_agent_rates_payload_version();
 
         let mut change_queue = vec![0u8; change_queue_size as usize];


### PR DESCRIPTION
## What

The `WasmSpanState` constructor builds a `TraceExporterBuilder` and sets url/service/env/hostname/app_version, but never called `set_runtime_id`. The `runtime_id` passed into the constructor was only used for the stats collector (`StatsMeta`), not the trace exporter. This PR passes that same `runtime_id` to the exporter builder.

## Why

libdatadog's `TraceExporterBuilder` defaults `runtime_id` to `uuid::Uuid::new_v4()` at build time (`libdd-data-pipeline/src/trace_exporter/builder.rs`). With `runtime_id` unset, that default ran, which:

1. **Correlation bug** — gave the trace payload a *random* runtime-id that did not match the stats payload's runtime-id (which already used the tracer's real runtime-id).
2. **Wasm trap** — called `getrandom`, which panics (`could not retrieve random bytes for uuid` → `RuntimeError: unreachable`) on wasm runtimes without a configured entropy source. This surfaced as widespread failures in dd-trace-js System Tests / E2E: the pipeline trapped at `build_async`, so no spans were ever exported.

Passing the runtime-id the caller already provides fixes both — the `unwrap_or_else(Uuid::new_v4)` closure never runs (no getrandom call on the build path), and the trace/stats runtime-ids match.

## Test plan

- `node --test --test-force-exit test/pipeline.js` → 45/45
- `node --test --test-force-exit test/http_transport.js` → 6/6
- Clean wasm rebuild; binding loads
- The trap only reproduces in the CI/System-Tests runtime (local always has an entropy source); causation rests on the removed `Uuid::new_v4()` code path, verified by review.

Unblocks dd-trace-js #9139 (native-spans) System Tests / E2E.
