### PR TITLE
v0.12.1

### DIFF
--- a/crates/pipeline/src/lib.rs
+++ b/crates/pipeline/src/lib.rs
@@ -248,6 +248,7 @@ impl WasmSpanState {
             .set_env(env)
             .set_hostname(hostname)
             .set_app_version(app_version)
+            .set_runtime_id(runtime_id)
             .enable_agent_rates_payload_version();
 
         let mut change_queue = vec![0u8; change_queue_size as usize];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/libdatadog",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Node.js binding for libdatadog",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Release 0.12.1

Patch release backporting the pipeline exporter runtime-id fix onto the 0.12.x line.

### Included
- **#157** `fix(pipeline): set exporter runtime-id from the tracer` — the `TraceExporterBuilder` never called `set_runtime_id`, so it defaulted to `Uuid::new_v4()` at `build_async`. That gave the trace payload a random runtime-id mismatching the stats payload (correlation bug) and called `getrandom`, which traps on wasm runtimes without an entropy source (surfaced as widespread native-spans System Tests / E2E failures in dd-trace-js — the pipeline trapped at exporter build, so no spans exported).

### Verification (on the 0.12.0 base)
- `node --test --test-force-exit test/pipeline.js` → 45/45
- `node --test --test-force-exit test/http_transport.js` → 6/6
- Clean wasm rebuild

Rebase-and-merge (matching the v0.x release-branch convention) to publish 0.12.1.
