### PR TITLE
v0.13.0

### DIFF
--- a/crates/pipeline/src/lib.rs
+++ b/crates/pipeline/src/lib.rs
@@ -236,6 +236,7 @@ impl WasmSpanState {
         env: &str,
         app_version: &str,
         runtime_id: &str,
+        client_computed_stats: bool,
     ) -> Result<WasmSpanState, JsValue> {
         let mut builder = TraceExporterBuilder::<LocalRuntime>::new();
         builder
@@ -254,6 +255,19 @@ impl WasmSpanState {
             .set_app_version(app_version)
             .set_runtime_id(runtime_id)
             .enable_agent_rates_payload_version();
+
+        // Advertise `Datadog-Client-Computed-Stats` so the agent skips its own
+        // APM stats/sampling for these traces. This is required in two cases:
+        //  - `stats_enabled`: we build a StatsCollector and send client-side
+        //    stats, so the agent MUST NOT also compute them (double counting);
+        //  - `client_computed_stats`: set independently for APM-standalone
+        //    (apmTracingEnabled=false), where the agent should skip APM stats
+        //    even though we don't compute them client-side.
+        // Enabling stats therefore always implies the header, so OR the flags
+        // rather than relying on the caller to keep them in sync.
+        if client_computed_stats || stats_enabled {
+            builder.set_client_computed_stats();
+        }
 
         let mut change_queue = vec![0u8; change_queue_size as usize];
         let change_buffer = unsafe {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/libdatadog",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "Node.js binding for libdatadog",
   "main": "index.js",
   "scripts": {

--- a/test/pipeline.js
+++ b/test/pipeline.js
@@ -167,6 +167,7 @@ class NativeSpansInterface {
       options.env || 'test-env',
       options.appVersion || '1.0.0',
       options.runtimeId || '00000000-0000-0000-0000-000000000000',
+      options.clientComputedStats ?? false,
     )
 
     // Get pointers into WASM memory for direct buffer access
@@ -1013,6 +1014,61 @@ describe('pipeline', { skip }, () => {
     it('rejects unsupported OTLP protocols (e.g. grpc)', () => {
       const ns = new NativeSpansInterface({ agentUrl: 'http://127.0.0.1:8126' })
       assert.throws(() => ns.state.setOtlpProtocol('grpc'), /setOtlpProtocol|not supported/)
+    })
+  })
+
+  describe('client-computed-stats header', () => {
+    async function captureTraceHeader (nsOptions) {
+      const http = require('node:http')
+      let header
+      let sawTraces = false
+      const server = http.createServer((req, res) => {
+        req.on('data', () => {})
+        req.on('end', () => {
+          if (req.url === '/v0.4/traces') {
+            sawTraces = true
+            header = req.headers['datadog-client-computed-stats']
+          }
+          res.writeHead(200, { 'content-type': 'application/json' })
+          res.end('{}')
+        })
+      })
+      await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+      const { port } = server.address()
+      const ns = new NativeSpansInterface({ agentUrl: `http://127.0.0.1:${port}`, ...nsOptions })
+      const span = ns.createSpan()
+      span.name = 'span'
+      span.service = 'test-service'
+      span.resource = 'test-resource'
+      span.type = 'web'
+      span.duration = 1_000_000n
+      try {
+        await ns.flushSpans(span)
+        return { header, sawTraces }
+      } finally {
+        server.closeAllConnections?.()
+        server.close()
+      }
+    }
+
+    it('sends Datadog-Client-Computed-Stats: true when enabled', async () => {
+      const { header, sawTraces } = await captureTraceHeader({ clientComputedStats: true })
+      assert.ok(sawTraces, 'expected a POST to /v0.4/traces')
+      assert.strictEqual(header, 'true')
+    })
+
+    it('omits the header when both flags are disabled', async () => {
+      const { header, sawTraces } = await captureTraceHeader({ clientComputedStats: false, statsEnabled: false })
+      assert.ok(sawTraces, 'expected a POST to /v0.4/traces')
+      assert.strictEqual(header, undefined)
+    })
+
+    it('sends the header when stats are enabled (client-side stats imply it)', async () => {
+      // Enabling client-side stats without clientComputedStats must still send
+      // the header, otherwise the agent double-counts APM stats.
+      const { header, sawTraces } = await captureTraceHeader({ statsEnabled: true, clientComputedStats: false })
+      assert.ok(sawTraces, 'expected a POST to /v0.4/traces')
+      assert.strictEqual(header, 'true')
     })
   })
 


### PR DESCRIPTION
Release 0.13.0.

Includes:
- feat(pipeline): send `Datadog-Client-Computed-Stats` when enabled (#164) — the exporter now advertises the header when the tracer computes stats client-side or runs in APM-standalone, so the agent skips its own APM stats/sampling.

Unblocks dd-trace-js native-spans (#9139): ~46 ASM-standalone system-tests asserting the header, plus client-computed stats being honored.

Rebase-and-merge to `v0.x` to trigger the Release workflow (npm publish gate + `v0.13.0` tag).
