### PR TITLE
feat: added env capability [APMSP-3780]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
  "libdd-shared-runtime 2.0.0",
  "libdd-tinybytes",
  "libdd-trace-normalization",
- "libdd-trace-protobuf 4.0.0",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog.git?rev=3081603d3c74f209be4e3be951f78a1a7469397f)",
  "libdd-trace-stats",
  "libdd-trace-utils",
  "rmp-serde",
@@ -1117,26 +1117,12 @@ dependencies = [
 
 [[package]]
 name = "libdd-library-config"
-version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=353134770b312b7ccd2df6afabc253090b948e5f#353134770b312b7ccd2df6afabc253090b948e5f"
-dependencies = [
- "anyhow",
- "memfd",
- "rand",
- "rmp",
- "rmp-serde",
- "serde",
- "serde_yaml",
-]
-
-[[package]]
-name = "libdd-library-config"
-version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=7cdeb7896e92d1ba38bde495934e112dac2eda25#7cdeb7896e92d1ba38bde495934e112dac2eda25"
+version = "3.0.0"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=0c6e2a5df2a163d34c4f385353ffc5d7257c72f4#0c6e2a5df2a163d34c4f385353ffc5d7257c72f4"
 dependencies = [
  "anyhow",
  "libc",
- "libdd-trace-protobuf 3.0.2",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog.git?rev=0c6e2a5df2a163d34c4f385353ffc5d7257c72f4)",
  "memfd",
  "prost",
  "rand",
@@ -1232,7 +1218,7 @@ version = "3.0.0"
 source = "git+https://github.com/DataDog/libdatadog.git?rev=3081603d3c74f209be4e3be951f78a1a7469397f#3081603d3c74f209be4e3be951f78a1a7469397f"
 dependencies = [
  "anyhow",
- "libdd-trace-protobuf 4.0.0",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog.git?rev=3081603d3c74f209be4e3be951f78a1a7469397f)",
 ]
 
 [[package]]
@@ -1243,7 +1229,7 @@ dependencies = [
  "anyhow",
  "fluent-uri",
  "libdd-common 5.1.0",
- "libdd-trace-protobuf 4.0.0",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog.git?rev=3081603d3c74f209be4e3be951f78a1a7469397f)",
  "libdd-trace-utils",
  "log",
  "percent-encoding",
@@ -1253,8 +1239,8 @@ dependencies = [
 
 [[package]]
 name = "libdd-trace-protobuf"
-version = "3.0.2"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=7cdeb7896e92d1ba38bde495934e112dac2eda25#7cdeb7896e92d1ba38bde495934e112dac2eda25"
+version = "4.0.0"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=0c6e2a5df2a163d34c4f385353ffc5d7257c72f4#0c6e2a5df2a163d34c4f385353ffc5d7257c72f4"
 dependencies = [
  "prost",
  "serde",
@@ -1289,7 +1275,7 @@ dependencies = [
  "libdd-dogstatsd-client",
  "libdd-shared-runtime 2.0.0",
  "libdd-trace-obfuscation",
- "libdd-trace-protobuf 4.0.0",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog.git?rev=3081603d3c74f209be4e3be951f78a1a7469397f)",
  "libdd-trace-utils",
  "rmp-serde",
  "serde",
@@ -1320,7 +1306,7 @@ dependencies = [
  "libdd-common 5.1.0",
  "libdd-tinybytes",
  "libdd-trace-normalization",
- "libdd-trace-protobuf 4.0.0",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog.git?rev=3081603d3c74f209be4e3be951f78a1a7469397f)",
  "prost",
  "rand",
  "rmp",
@@ -1357,7 +1343,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "getrandom 0.2.17",
- "libdd-library-config 1.0.0",
+ "libdd-library-config",
  "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",
@@ -1811,7 +1797,7 @@ dependencies = [
  "libdd-common 5.1.0",
  "libdd-data-pipeline",
  "libdd-shared-runtime 2.0.0",
- "libdd-trace-protobuf 4.0.0",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog.git?rev=3081603d3c74f209be4e3be951f78a1a7469397f)",
  "libdd-trace-stats",
  "libdd-trace-utils",
  "rmp-serde",
@@ -1872,8 +1858,8 @@ name = "process-discovery"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "libdd-library-config 2.0.0",
- "libdd-trace-protobuf 3.0.2",
+ "libdd-library-config",
+ "libdd-trace-protobuf 4.0.0 (git+https://github.com/DataDog/libdatadog.git?rev=0c6e2a5df2a163d34c4f385353ffc5d7257c72f4)",
  "napi",
  "napi-derive",
 ]

--- a/crates/capabilities/src/env.rs
+++ b/crates/capabilities/src/env.rs
@@ -1,0 +1,49 @@
+// Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+//! Wasm implementation of [`EnvCapability`] backed by Node.js `process.env`.
+
+use wasm_bindgen::prelude::*;
+
+use libdd_capabilities::env::{EnvCapability, EnvError};
+
+#[wasm_bindgen(module = "/src/env_transport.js")]
+extern "C" {
+    #[wasm_bindgen(js_name = "get")]
+    fn js_env_get(name: &str) -> JsValue;
+
+    #[wasm_bindgen(js_name = "set")]
+    fn js_env_set(name: &str, value: &str);
+
+    #[wasm_bindgen(js_name = "unset")]
+    fn js_env_unset(name: &str);
+}
+
+#[derive(Debug, Clone)]
+pub struct WasmEnvCapability;
+
+impl EnvCapability for WasmEnvCapability {
+    fn new() -> Self {
+        Self
+    }
+
+    fn get(&self, name: &str) -> Result<Option<String>, EnvError> {
+        // Node coerces every process.env value to a string, so NotUnicode is unreachable here.
+        let value = js_env_get(name);
+        if value.is_undefined() || value.is_null() {
+            Ok(None)
+        } else {
+            Ok(value.as_string())
+        }
+    }
+
+    fn set(&self, name: &str, value: &str) -> Result<(), EnvError> {
+        js_env_set(name, value);
+        Ok(())
+    }
+
+    fn unset(&self, name: &str) -> Result<(), EnvError> {
+        js_env_unset(name);
+        Ok(())
+    }
+}

--- a/crates/capabilities/src/env.rs
+++ b/crates/capabilities/src/env.rs
@@ -5,18 +5,12 @@
 
 use wasm_bindgen::prelude::*;
 
-use libdd_capabilities::env::{validate_name, validate_value, EnvCapability, EnvError};
+use libdd_capabilities::env::{EnvCapability, EnvError};
 
 #[wasm_bindgen(module = "/src/env_transport.js")]
 extern "C" {
     #[wasm_bindgen(js_name = "get")]
     fn js_env_get(name: &str) -> JsValue;
-
-    #[wasm_bindgen(js_name = "set")]
-    fn js_env_set(name: &str, value: &str);
-
-    #[wasm_bindgen(js_name = "unset")]
-    fn js_env_unset(name: &str);
 }
 
 #[derive(Debug, Clone)]
@@ -35,20 +29,5 @@ impl EnvCapability for WasmEnvCapability {
         } else {
             Ok(value.as_string())
         }
-    }
-
-    unsafe fn set(&self, name: &str, value: &str) -> Result<(), EnvError> {
-        validate_name(name)?;
-        validate_value(value)?;
-        // SAFETY: Wasm is single-threaded; no concurrent env access is possible.
-        js_env_set(name, value);
-        Ok(())
-    }
-
-    unsafe fn unset(&self, name: &str) -> Result<(), EnvError> {
-        validate_name(name)?;
-        // SAFETY: Wasm is single-threaded; no concurrent env access is possible.
-        js_env_unset(name);
-        Ok(())
     }
 }

--- a/crates/capabilities/src/env.rs
+++ b/crates/capabilities/src/env.rs
@@ -37,12 +37,14 @@ impl EnvCapability for WasmEnvCapability {
         }
     }
 
-    fn set(&self, name: &str, value: &str) -> Result<(), EnvError> {
+    unsafe fn set(&self, name: &str, value: &str) -> Result<(), EnvError> {
+        // SAFETY: Wasm is single-threaded; no concurrent env access is possible.
         js_env_set(name, value);
         Ok(())
     }
 
-    fn unset(&self, name: &str) -> Result<(), EnvError> {
+    unsafe fn unset(&self, name: &str) -> Result<(), EnvError> {
+        // SAFETY: Wasm is single-threaded; no concurrent env access is possible.
         js_env_unset(name);
         Ok(())
     }

--- a/crates/capabilities/src/env.rs
+++ b/crates/capabilities/src/env.rs
@@ -5,7 +5,7 @@
 
 use wasm_bindgen::prelude::*;
 
-use libdd_capabilities::env::{EnvCapability, EnvError};
+use libdd_capabilities::env::{validate_name, validate_value, EnvCapability, EnvError};
 
 #[wasm_bindgen(module = "/src/env_transport.js")]
 extern "C" {
@@ -38,12 +38,15 @@ impl EnvCapability for WasmEnvCapability {
     }
 
     unsafe fn set(&self, name: &str, value: &str) -> Result<(), EnvError> {
+        validate_name(name)?;
+        validate_value(value)?;
         // SAFETY: Wasm is single-threaded; no concurrent env access is possible.
         js_env_set(name, value);
         Ok(())
     }
 
     unsafe fn unset(&self, name: &str) -> Result<(), EnvError> {
+        validate_name(name)?;
         // SAFETY: Wasm is single-threaded; no concurrent env access is possible.
         js_env_unset(name);
         Ok(())

--- a/crates/capabilities/src/env.rs
+++ b/crates/capabilities/src/env.rs
@@ -23,11 +23,6 @@ impl EnvCapability for WasmEnvCapability {
 
     fn get(&self, name: &str) -> Result<Option<String>, EnvError> {
         // Node coerces every process.env value to a string, so NotUnicode is unreachable here.
-        let value = js_env_get(name);
-        if value.is_undefined() || value.is_null() {
-            Ok(None)
-        } else {
-            Ok(value.as_string())
-        }
+        Ok(js_env_get(name).as_string())
     }
 }

--- a/crates/capabilities/src/env_transport.js
+++ b/crates/capabilities/src/env_transport.js
@@ -3,11 +3,3 @@
 module.exports.get = function (name) {
   return process.env[name]
 }
-
-module.exports.set = function (name, value) {
-  process.env[name] = value
-}
-
-module.exports.unset = function (name) {
-  delete process.env[name]
-}

--- a/crates/capabilities/src/env_transport.js
+++ b/crates/capabilities/src/env_transport.js
@@ -1,5 +1,7 @@
 'use strict'
 
-module.exports.get = function (name) {
-  return process.env[name]
+const { env } = process
+
+module.exports.get = (name) => {
+  return env[name]
 }

--- a/crates/capabilities/src/env_transport.js
+++ b/crates/capabilities/src/env_transport.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports.get = function (name) {
+  return process.env[name]
+}
+
+module.exports.set = function (name, value) {
+  process.env[name] = value
+}
+
+module.exports.unset = function (name) {
+  delete process.env[name]
+}

--- a/crates/capabilities/src/lib.rs
+++ b/crates/capabilities/src/lib.rs
@@ -135,14 +135,4 @@ impl EnvCapability for WasmCapabilities {
     fn get(&self, name: &str) -> Result<Option<String>, EnvError> {
         self.env.get(name)
     }
-
-    unsafe fn set(&self, name: &str, value: &str) -> Result<(), EnvError> {
-        // SAFETY: forwarded verbatim; Wasm is single-threaded so the precondition is trivially upheld.
-        unsafe { self.env.set(name, value) }
-    }
-
-    unsafe fn unset(&self, name: &str) -> Result<(), EnvError> {
-        // SAFETY: forwarded verbatim; Wasm is single-threaded so the precondition is trivially upheld.
-        unsafe { self.env.unset(name) }
-    }
 }

--- a/crates/capabilities/src/lib.rs
+++ b/crates/capabilities/src/lib.rs
@@ -12,14 +12,17 @@
 use std::future::Future;
 use std::time::Duration;
 
+use libdd_capabilities::env::{EnvCapability, EnvError};
 use libdd_capabilities::file::{FileCapability, FileError, FileMetadata};
 use libdd_capabilities::http::HttpError;
 use libdd_capabilities::{HttpClientCapability, LogWriterCapability, MaybeSend, SleepCapability};
 
+pub mod env;
 pub mod file;
 pub mod http;
 pub mod sleep;
 
+pub use env::WasmEnvCapability;
 pub use file::WasmFileCapability;
 pub use http::WasmHttpClient;
 pub use sleep::WasmSleepCapability;
@@ -38,6 +41,7 @@ pub struct WasmCapabilities {
     sleep: WasmSleepCapability,
     /// Filesystem access delegated to the Node.js `fs` transport.
     file: WasmFileCapability,
+    env: WasmEnvCapability,
 }
 
 impl Default for WasmCapabilities {
@@ -52,6 +56,7 @@ impl WasmCapabilities {
             http: WasmHttpClient::new_client(),
             sleep: WasmSleepCapability,
             file: WasmFileCapability,
+            env: WasmEnvCapability,
         }
     }
 }
@@ -122,3 +127,20 @@ impl FileCapability for WasmCapabilities {
     }
 }
 
+impl EnvCapability for WasmCapabilities {
+    fn new() -> Self {
+        Self::new()
+    }
+
+    fn get(&self, name: &str) -> Result<Option<String>, EnvError> {
+        self.env.get(name)
+    }
+
+    fn set(&self, name: &str, value: &str) -> Result<(), EnvError> {
+        self.env.set(name, value)
+    }
+
+    fn unset(&self, name: &str) -> Result<(), EnvError> {
+        self.env.unset(name)
+    }
+}

--- a/crates/capabilities/src/lib.rs
+++ b/crates/capabilities/src/lib.rs
@@ -4,10 +4,9 @@
 //! Wasm capability implementations for libdatadog-nodejs.
 //!
 //! [`WasmCapabilities`] is the bundle struct that implements every capability
-//! trait `TraceExporter` requires (HTTP, sleep, log output) using wasm_bindgen
-//! and JS transports. The wasm binding crate pins this type as the capability
-//! generic for libdatadog's `TraceExporter`, mirroring libdatadog's native
-//! `NativeCapabilities`.
+//! trait `TraceExporter` requires using wasm_bindgen and JS transports. The
+//! wasm binding crate pins this type as the capability generic for libdatadog's
+//! `TraceExporter`, mirroring libdatadog's native `NativeCapabilities`.
 
 use std::future::Future;
 use std::time::Duration;

--- a/crates/capabilities/src/lib.rs
+++ b/crates/capabilities/src/lib.rs
@@ -136,11 +136,13 @@ impl EnvCapability for WasmCapabilities {
         self.env.get(name)
     }
 
-    fn set(&self, name: &str, value: &str) -> Result<(), EnvError> {
-        self.env.set(name, value)
+    unsafe fn set(&self, name: &str, value: &str) -> Result<(), EnvError> {
+        // SAFETY: forwarded verbatim; Wasm is single-threaded so the precondition is trivially upheld.
+        unsafe { self.env.set(name, value) }
     }
 
-    fn unset(&self, name: &str) -> Result<(), EnvError> {
-        self.env.unset(name)
+    unsafe fn unset(&self, name: &str) -> Result<(), EnvError> {
+        // SAFETY: forwarded verbatim; Wasm is single-threaded so the precondition is trivially upheld.
+        unsafe { self.env.unset(name) }
     }
 }

--- a/crates/library_config/Cargo.toml
+++ b/crates/library_config/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "1"
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog.git", branch = "jwiriath/env-caps" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog.git", rev = "0c6e2a5df2a163d34c4f385353ffc5d7257c72f4" }
 
 wasm-bindgen = "0.2.100"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/library_config/Cargo.toml
+++ b/crates/library_config/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "1"
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog.git", rev = "353134770b312b7ccd2df6afabc253090b948e5f" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog.git", branch = "jwiriath/env-caps" }
 
 wasm-bindgen = "0.2.100"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/process_discovery/Cargo.toml
+++ b/crates/process_discovery/Cargo.toml
@@ -8,11 +8,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "1"
-# Pointed at the merge commit that introduced ThreadLocalMetadata (caller-supplied
-# schema version + extra process-context attributes). Swap back to a tagged release
-# once one that includes 7cdeb7896e92d1ba38bde495934e112dac2eda25 is published.
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog.git", rev = "7cdeb7896e92d1ba38bde495934e112dac2eda25", features = ["otel-thread-ctx"] }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog.git", rev = "7cdeb7896e92d1ba38bde495934e112dac2eda25" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog.git", branch = "jwiriath/env-caps", features = ["otel-thread-ctx"] }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog.git", branch = "jwiriath/env-caps" }
 
 napi = { version = "2" }
 napi-derive = { version = "2", default-features = false }

--- a/crates/process_discovery/Cargo.toml
+++ b/crates/process_discovery/Cargo.toml
@@ -8,8 +8,8 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "1"
-libdd-library-config = { git = "https://github.com/DataDog/libdatadog.git", branch = "jwiriath/env-caps", features = ["otel-thread-ctx"] }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog.git", branch = "jwiriath/env-caps" }
+libdd-library-config = { git = "https://github.com/DataDog/libdatadog.git", rev = "0c6e2a5df2a163d34c4f385353ffc5d7257c72f4", features = ["otel-thread-ctx"] }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog.git", rev = "0c6e2a5df2a163d34c4f385353ffc5d7257c72f4" }
 
 napi = { version = "2" }
 napi-derive = { version = "2", default-features = false }

--- a/test/env-transport.js
+++ b/test/env-transport.js
@@ -24,14 +24,8 @@ describe('env_transport', () => {
     assert.strictEqual(envTransport.get(NAME), undefined)
   })
 
-  it('set then get round-trips the value', () => {
-    envTransport.set(NAME, 'value1')
+  it('returns the value when the var is set', () => {
+    process.env[NAME] = 'value1'
     assert.strictEqual(envTransport.get(NAME), 'value1')
-  })
-
-  it('unset then get returns undefined', () => {
-    envTransport.set(NAME, 'value2')
-    envTransport.unset(NAME)
-    assert.strictEqual(envTransport.get(NAME), undefined)
   })
 })

--- a/test/env-transport.js
+++ b/test/env-transport.js
@@ -1,0 +1,37 @@
+'use strict'
+
+// The transport shim is plain CommonJS, so drive it directly.
+
+const { describe, it, before, after } = require('node:test')
+const assert = require('node:assert')
+
+const envTransport = require('../crates/capabilities/src/env_transport')
+
+describe('env_transport', () => {
+  const NAME = 'LIBDD_CAP_TEST_ENV_TRANSPORT'
+  let savedValue
+
+  before(() => {
+    savedValue = process.env[NAME]
+  })
+  after(() => {
+    if (savedValue === undefined) delete process.env[NAME]
+    else process.env[NAME] = savedValue
+  })
+
+  it('returns undefined for an unset var', () => {
+    delete process.env[NAME]
+    assert.strictEqual(envTransport.get(NAME), undefined)
+  })
+
+  it('set then get round-trips the value', () => {
+    envTransport.set(NAME, 'value1')
+    assert.strictEqual(envTransport.get(NAME), 'value1')
+  })
+
+  it('unset then get returns undefined', () => {
+    envTransport.set(NAME, 'value2')
+    envTransport.unset(NAME)
+    assert.strictEqual(envTransport.get(NAME), undefined)
+  })
+})


### PR DESCRIPTION
# What ?

Implement js side of EnvCapabilities for fetching environment variables.

# Why ?

Required #166 mentioned comment, these should be done by libdatadog so that libdatadog-nodejs don't need to fetch those like this.

# How ?

New capability for fetching the environment driven by Rust