### PR TITLE
v0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,7 +858,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities"
 version = "2.1.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=6356aee4c69b51f27e7e82e43b1797f60b74905a#6356aee4c69b51f27e7e82e43b1797f60b74905a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -882,7 +882,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=6356aee4c69b51f27e7e82e43b1797f60b74905a#6356aee4c69b51f27e7e82e43b1797f60b74905a"
 dependencies = [
  "bytes",
  "http",
@@ -929,7 +929,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "5.1.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=6356aee4c69b51f27e7e82e43b1797f60b74905a#6356aee4c69b51f27e7e82e43b1797f60b74905a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -992,7 +992,7 @@ dependencies = [
 [[package]]
 name = "libdd-data-pipeline"
 version = "7.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=6356aee4c69b51f27e7e82e43b1797f60b74905a#6356aee4c69b51f27e7e82e43b1797f60b74905a"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1034,7 +1034,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=6356aee4c69b51f27e7e82e43b1797f60b74905a#6356aee4c69b51f27e7e82e43b1797f60b74905a"
 dependencies = [
  "prost",
 ]
@@ -1042,7 +1042,7 @@ dependencies = [
 [[package]]
 name = "libdd-dogstatsd-client"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=6356aee4c69b51f27e7e82e43b1797f60b74905a#6356aee4c69b51f27e7e82e43b1797f60b74905a"
 dependencies = [
  "anyhow",
  "cadence",
@@ -1114,7 +1114,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=6356aee4c69b51f27e7e82e43b1797f60b74905a#6356aee4c69b51f27e7e82e43b1797f60b74905a"
 dependencies = [
  "async-trait",
  "futures",
@@ -1158,7 +1158,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.1"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=6356aee4c69b51f27e7e82e43b1797f60b74905a#6356aee4c69b51f27e7e82e43b1797f60b74905a"
 dependencies = [
  "serde",
 ]
@@ -1166,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=6356aee4c69b51f27e7e82e43b1797f60b74905a#6356aee4c69b51f27e7e82e43b1797f60b74905a"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf 4.0.0",
@@ -1175,7 +1175,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-obfuscation"
 version = "5.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=6356aee4c69b51f27e7e82e43b1797f60b74905a#6356aee4c69b51f27e7e82e43b1797f60b74905a"
 dependencies = [
  "anyhow",
  "fluent-uri",
@@ -1201,7 +1201,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=6356aee4c69b51f27e7e82e43b1797f60b74905a#6356aee4c69b51f27e7e82e43b1797f60b74905a"
 dependencies = [
  "prost",
  "serde",
@@ -1211,7 +1211,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-stats"
 version = "6.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=6356aee4c69b51f27e7e82e43b1797f60b74905a#6356aee4c69b51f27e7e82e43b1797f60b74905a"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1238,7 +1238,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-utils"
 version = "9.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=6356aee4c69b51f27e7e82e43b1797f60b74905a#6356aee4c69b51f27e7e82e43b1797f60b74905a"
 dependencies = [
  "anyhow",
  "base64",
@@ -1250,6 +1250,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "indexmap",
+ "itoa",
  "libdd-capabilities 2.1.0",
  "libdd-capabilities-impl 3.0.0",
  "libdd-common 5.1.0",

--- a/crates/capabilities/Cargo.toml
+++ b/crates/capabilities/Cargo.toml
@@ -17,7 +17,7 @@ futures-core = "0.3"
 anyhow = "1"
 # TODO: Replace this temporary libdatadog PR rev with the official release/tag
 # that contains DataDog/libdatadog#2235, then regenerate Cargo.lock.
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af" }
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog.git", rev = "6356aee4c69b51f27e7e82e43b1797f60b74905a" }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/pipeline/Cargo.toml
+++ b/crates/pipeline/Cargo.toml
@@ -16,13 +16,13 @@ serde_json = "1"
 libdatadog-nodejs-capabilities = { path = "../capabilities" }
 # TODO: Replace these temporary libdatadog PR revs with the official release/tag
 # that contains DataDog/libdatadog#2235, then regenerate Cargo.lock.
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af", default-features = false }
-libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af", default-features = false }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af", default-features = false, features = ["change-buffer"] }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af", default-features = false }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af", default-features = false }
-libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af", default-features = false }
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog.git", rev = "6356aee4c69b51f27e7e82e43b1797f60b74905a" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog.git", rev = "6356aee4c69b51f27e7e82e43b1797f60b74905a", default-features = false }
+libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog.git", rev = "6356aee4c69b51f27e7e82e43b1797f60b74905a", default-features = false }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog.git", rev = "6356aee4c69b51f27e7e82e43b1797f60b74905a", default-features = false, features = ["change-buffer"] }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog.git", rev = "6356aee4c69b51f27e7e82e43b1797f60b74905a", default-features = false }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog.git", rev = "6356aee4c69b51f27e7e82e43b1797f60b74905a", default-features = false }
+libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog.git", rev = "6356aee4c69b51f27e7e82e43b1797f60b74905a", default-features = false }
 rmp-serde = "1"
 bytes = "1"
 http = "1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/libdatadog",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Node.js binding for libdatadog",
   "main": "index.js",
   "scripts": {

--- a/test/pipeline.js
+++ b/test/pipeline.js
@@ -239,7 +239,7 @@ class NativeSpansInterface {
       this.cqbCount = 0
     }
 
-    const view = this._cqbView
+    let view = this._cqbView
     // Op header: opcode (u16 LE) + span_id (u64 LE) = 10 bytes. Rust reads the
     // opcode as a u16, then the span_id as a u64.
     view.setUint16(this.cqbIndex, op, true)
@@ -250,6 +250,10 @@ class NativeSpansInterface {
     for (const arg of args) {
       if (typeof arg === 'string') {
         const stringId = this.getStringId(arg)
+        if (this._wasmMemory.buffer !== view.buffer) {
+          this._refreshViews()
+          view = this._cqbView
+        }
         view.setUint32(this.cqbIndex, stringId, true)
         this.cqbIndex += 4
       } else {
@@ -741,6 +745,28 @@ describe('pipeline', { skip }, () => {
       const span = nativeSpans.createSpan()
       nativeSpans.queueOp(OpCode.SetMetaAttr, span.spanId, ['u32n', 60_001], ['u32n', 60_002])
       assert.strictEqual(span.getTag('bulk-key'), 'bulk-val')
+    })
+
+    it('refreshes change-buffer views when string interning grows memory', () => {
+      const span = nativeSpans.createSpan()
+      const getStringId = nativeSpans.getStringId.bind(nativeSpans)
+      let grew = false
+      nativeSpans.getStringId = (str) => {
+        const id = getStringId(str)
+        if (!grew) {
+          grew = true
+          wasmMemory.grow(1)
+        }
+        return id
+      }
+
+      try {
+        span.setTag('grow-key', 'grow-value')
+
+        assert.strictEqual(span.getTag('grow-key'), 'grow-value')
+      } finally {
+        nativeSpans.getStringId = getStringId
+      }
     })
 
     it('rejects a malformed (non-terminated) stringTableInsertMany entry', () => {

--- a/test/pipeline.js
+++ b/test/pipeline.js
@@ -970,6 +970,7 @@ describe('pipeline', { skip }, () => {
             method: req.method,
             url: req.url,
             ct: req.headers['content-type'],
+            clientComputedStats: req.headers['datadog-client-computed-stats'],
             len: Buffer.concat(chunks).length,
             body: Buffer.concat(chunks).toString(),
           })
@@ -982,6 +983,7 @@ describe('pipeline', { skip }, () => {
       const ns = new NativeSpansInterface({
         agentUrl: `http://127.0.0.1:${port}`,
         tracerVersion: '7.0.0-pre',
+        clientComputedStats: true,
       })
       ns.state.setOtlpEndpoint(`http://127.0.0.1:${port}/v1/traces`)
       const span = ns.createSpan()
@@ -1001,6 +1003,11 @@ describe('pipeline', { skip }, () => {
         const body = JSON.parse(req.body)
         assert.strictEqual(body.resourceSpans[0].scopeSpans[0].scope.name, 'dd-trace-js')
         assert.strictEqual(body.resourceSpans[0].scopeSpans[0].scope.version, '7.0.0-pre')
+        assert.strictEqual(req.clientComputedStats, 'yes')
+        const resourceAttrs = body.resourceSpans[0].resource.attributes
+        assert.ok(resourceAttrs.some((attr) => {
+          return attr.key === '_dd.stats_computed' && attr.value.stringValue === 'true'
+        }), 'OTLP resource should mark client-computed stats')
       } finally {
         server.closeAllConnections?.()
         server.close()


### PR DESCRIPTION
## Summary
- release `@datadog/libdatadog@0.18.0`
- keep the v0.17 release fix that refreshes change-buffer views after WASM memory grows during string interning
- bump the pipeline/capabilities libdatadog rev to DataDog/libdatadog#2245 commit `6356aee4c69b51f27e7e82e43b1797f60b74905a`
- cover OTLP `clientComputedStats` exports carrying both `datadog-client-computed-stats: yes` and Resource `_dd.stats_computed=true`

## Context
`dd-trace-js` computes OTLP span metrics in JS. The native OTLP trace export path needs the client-computed stats marker from libdatadog so the Agent does not recompute the same stats. DataDog/libdatadog#2245 adds that marker when tracer metadata says client stats are computed.

This PR also keeps the existing release-workflow fix from the previous branch state: `queueOp()` must refresh WASM memory views after `getStringId()` because string interning can grow memory and detach the old `DataView`.

## Verification
- RED: before rebuilding the pipeline artifact from the new libdatadog rev, the new OTLP assertion failed with `undefined !== 'yes'` for `datadog-client-computed-stats`
- GREEN: `cargo build -p pipeline --target wasm32-unknown-unknown`
- GREEN: `/Users/bryan.english/.nvm/versions/node/v26.5.0/bin/node scripts/build-wasm.js pipeline && /Users/bryan.english/.nvm/versions/node/v26.5.0/bin/node --test-force-exit test/pipeline.js` passed 52/52
- GREEN: `PATH="/Users/bryan.english/.nvm/versions/node/v26.5.0/bin:$PATH" yarn -s lint`
