### PR TITLE
v0.17.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,7 +858,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities"
 version = "2.1.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=964bda07c990cdae9b56da0f0753954e4172728d#964bda07c990cdae9b56da0f0753954e4172728d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -882,7 +882,7 @@ dependencies = [
 [[package]]
 name = "libdd-capabilities-impl"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=964bda07c990cdae9b56da0f0753954e4172728d#964bda07c990cdae9b56da0f0753954e4172728d"
 dependencies = [
  "bytes",
  "http",
@@ -929,7 +929,7 @@ dependencies = [
 [[package]]
 name = "libdd-common"
 version = "5.1.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=964bda07c990cdae9b56da0f0753954e4172728d#964bda07c990cdae9b56da0f0753954e4172728d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -992,7 +992,7 @@ dependencies = [
 [[package]]
 name = "libdd-data-pipeline"
 version = "7.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=964bda07c990cdae9b56da0f0753954e4172728d#964bda07c990cdae9b56da0f0753954e4172728d"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1034,7 +1034,7 @@ dependencies = [
 [[package]]
 name = "libdd-ddsketch"
 version = "1.1.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=964bda07c990cdae9b56da0f0753954e4172728d#964bda07c990cdae9b56da0f0753954e4172728d"
 dependencies = [
  "prost",
 ]
@@ -1042,7 +1042,7 @@ dependencies = [
 [[package]]
 name = "libdd-dogstatsd-client"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=964bda07c990cdae9b56da0f0753954e4172728d#964bda07c990cdae9b56da0f0753954e4172728d"
 dependencies = [
  "anyhow",
  "cadence",
@@ -1114,7 +1114,7 @@ dependencies = [
 [[package]]
 name = "libdd-shared-runtime"
 version = "2.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=964bda07c990cdae9b56da0f0753954e4172728d#964bda07c990cdae9b56da0f0753954e4172728d"
 dependencies = [
  "async-trait",
  "futures",
@@ -1158,7 +1158,7 @@ dependencies = [
 [[package]]
 name = "libdd-tinybytes"
 version = "1.1.1"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=964bda07c990cdae9b56da0f0753954e4172728d#964bda07c990cdae9b56da0f0753954e4172728d"
 dependencies = [
  "serde",
 ]
@@ -1166,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-normalization"
 version = "3.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=964bda07c990cdae9b56da0f0753954e4172728d#964bda07c990cdae9b56da0f0753954e4172728d"
 dependencies = [
  "anyhow",
  "libdd-trace-protobuf 4.0.0",
@@ -1175,7 +1175,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-obfuscation"
 version = "5.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=964bda07c990cdae9b56da0f0753954e4172728d#964bda07c990cdae9b56da0f0753954e4172728d"
 dependencies = [
  "anyhow",
  "fluent-uri",
@@ -1201,7 +1201,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-protobuf"
 version = "4.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=964bda07c990cdae9b56da0f0753954e4172728d#964bda07c990cdae9b56da0f0753954e4172728d"
 dependencies = [
  "prost",
  "serde",
@@ -1211,7 +1211,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-stats"
 version = "6.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=964bda07c990cdae9b56da0f0753954e4172728d#964bda07c990cdae9b56da0f0753954e4172728d"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1238,7 +1238,7 @@ dependencies = [
 [[package]]
 name = "libdd-trace-utils"
 version = "9.0.0"
-source = "git+https://github.com/DataDog/libdatadog.git?rev=8cd68ab922fb7aade0f089ccfc91291d874673af#8cd68ab922fb7aade0f089ccfc91291d874673af"
+source = "git+https://github.com/DataDog/libdatadog.git?rev=964bda07c990cdae9b56da0f0753954e4172728d#964bda07c990cdae9b56da0f0753954e4172728d"
 dependencies = [
  "anyhow",
  "base64",

--- a/crates/capabilities/Cargo.toml
+++ b/crates/capabilities/Cargo.toml
@@ -17,7 +17,7 @@ futures-core = "0.3"
 anyhow = "1"
 # TODO: Replace this temporary libdatadog PR rev with the official release/tag
 # that contains DataDog/libdatadog#2235, then regenerate Cargo.lock.
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af" }
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog.git", rev = "964bda07c990cdae9b56da0f0753954e4172728d" }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/pipeline/Cargo.toml
+++ b/crates/pipeline/Cargo.toml
@@ -16,13 +16,13 @@ serde_json = "1"
 libdatadog-nodejs-capabilities = { path = "../capabilities" }
 # TODO: Replace these temporary libdatadog PR revs with the official release/tag
 # that contains DataDog/libdatadog#2235, then regenerate Cargo.lock.
-libdd-capabilities = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af", default-features = false }
-libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af", default-features = false }
-libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af", default-features = false, features = ["change-buffer"] }
-libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af", default-features = false }
-libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af", default-features = false }
-libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af", default-features = false }
+libdd-capabilities = { git = "https://github.com/DataDog/libdatadog.git", rev = "964bda07c990cdae9b56da0f0753954e4172728d" }
+libdd-common = { git = "https://github.com/DataDog/libdatadog.git", rev = "964bda07c990cdae9b56da0f0753954e4172728d", default-features = false }
+libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog.git", rev = "964bda07c990cdae9b56da0f0753954e4172728d", default-features = false }
+libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog.git", rev = "964bda07c990cdae9b56da0f0753954e4172728d", default-features = false, features = ["change-buffer"] }
+libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog.git", rev = "964bda07c990cdae9b56da0f0753954e4172728d", default-features = false }
+libdd-trace-protobuf = { git = "https://github.com/DataDog/libdatadog.git", rev = "964bda07c990cdae9b56da0f0753954e4172728d", default-features = false }
+libdd-shared-runtime = { git = "https://github.com/DataDog/libdatadog.git", rev = "964bda07c990cdae9b56da0f0753954e4172728d", default-features = false }
 rmp-serde = "1"
 bytes = "1"
 http = "1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datadog/libdatadog",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Node.js binding for libdatadog",
   "main": "index.js",
   "scripts": {

--- a/test/pipeline.js
+++ b/test/pipeline.js
@@ -239,7 +239,7 @@ class NativeSpansInterface {
       this.cqbCount = 0
     }
 
-    const view = this._cqbView
+    let view = this._cqbView
     // Op header: opcode (u16 LE) + span_id (u64 LE) = 10 bytes. Rust reads the
     // opcode as a u16, then the span_id as a u64.
     view.setUint16(this.cqbIndex, op, true)
@@ -250,6 +250,10 @@ class NativeSpansInterface {
     for (const arg of args) {
       if (typeof arg === 'string') {
         const stringId = this.getStringId(arg)
+        if (this._wasmMemory.buffer !== view.buffer) {
+          this._refreshViews()
+          view = this._cqbView
+        }
         view.setUint32(this.cqbIndex, stringId, true)
         this.cqbIndex += 4
       } else {
@@ -741,6 +745,24 @@ describe('pipeline', { skip }, () => {
       const span = nativeSpans.createSpan()
       nativeSpans.queueOp(OpCode.SetMetaAttr, span.spanId, ['u32n', 60_001], ['u32n', 60_002])
       assert.strictEqual(span.getTag('bulk-key'), 'bulk-val')
+    })
+
+    it('refreshes change-buffer views when string interning grows memory', () => {
+      const span = nativeSpans.createSpan()
+      const getStringId = nativeSpans.getStringId.bind(nativeSpans)
+      let grew = false
+      nativeSpans.getStringId = (str) => {
+        const id = getStringId(str)
+        if (!grew) {
+          grew = true
+          wasmMemory.grow(1)
+        }
+        return id
+      }
+
+      span.setTag('grow-key', 'grow-value')
+
+      assert.strictEqual(span.getTag('grow-key'), 'grow-value')
     })
 
     it('rejects a malformed (non-terminated) stringTableInsertMany entry', () => {


### PR DESCRIPTION
## What changed
- Pin the pipeline/capabilities libdatadog dependencies to DataDog/libdatadog@964bda07.
- Bump @datadog/libdatadog to 0.17.1.

## Verification
- cargo build -p pipeline --target wasm32-unknown-unknown