### PR TITLE
perf(pipeline): use regex-lite in the wasm build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,7 @@ dependencies = [
  "nix 0.29.0",
  "pin-project",
  "regex",
+ "regex-lite",
  "serde",
  "static_assertions",
  "thiserror",
@@ -1988,6 +1989,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"

--- a/crates/pipeline/Cargo.toml
+++ b/crates/pipeline/Cargo.toml
@@ -17,7 +17,13 @@ libdatadog-nodejs-capabilities = { path = "../capabilities" }
 # TODO: Replace these temporary libdatadog PR revs with the official release/tag
 # that contains DataDog/libdatadog#2235, then regenerate Cargo.lock.
 libdd-capabilities = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af" }
-libdd-common = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af", default-features = false }
+# `regex-lite` swaps libdd-common's regex engine for the `regex-lite` crate,
+# dropping the Unicode range tables that dominate this wasm module. Nothing in
+# the wasm build evaluates user-supplied regexes: libdd-trace-obfuscation and
+# libdd-trace-utils::trace_filter both go through `libdd_common::regex_engine`,
+# and `require-regex-full` (which would override this) is only enabled by
+# datadog-ffe, which is not in this dependency graph.
+libdd-common = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af", default-features = false, features = ["regex-lite"] }
 libdd-data-pipeline = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af", default-features = false }
 libdd-trace-utils = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af", default-features = false, features = ["change-buffer"] }
 libdd-trace-stats = { git = "https://github.com/DataDog/libdatadog.git", rev = "8cd68ab922fb7aade0f089ccfc91291d874673af", default-features = false }


### PR DESCRIPTION
## What

Enables `libdd-common`'s `regex-lite` feature for the `pipeline` wasm crate. This halves `pipeline_bg.wasm`.

All figures below are with `wasm-opt -O --all-features`, i.e. what CI actually publishes:

| | raw | gzip |
| --- | --- | --- |
| before | 1,507,189 | 564,771 |
| after | **754,457** | **304,880** |
| delta | **−752,732 (−49.9%)** | **−259,891 (−46.0%)** |

For reference, `pipeline_bg.wasm` in the published `@datadog/libdatadog@0.18.1` is 1,509,952 / 565,867 — the "before" row reproduces it.

Section breakdown:

| section | before | after |
| --- | --- | --- |
| `code` | 1,020,947 | 614,571 (−39.8%) |
| `data` | 477,819 | 131,060 (−72.6%) |
| └ binary static tables within `data` | ~393,704 | ~71,944 (−81.7%) |

## Why it was so big

`libdd-common` declares `regex = "1.5"` as a non-optional dependency, so every libdd crate drags in the full `regex` engine. `cargo tree --target wasm32-unknown-unknown` resolved it with every Unicode feature enabled — `unicode-age, unicode-bool, unicode-case, unicode-gencat, unicode-perl, unicode-script, unicode-segment` — plus all `perf-*` engines (DFA, onepass, backtrack, literal, cache).

The result was ~394 KB of Unicode range tables and a full regex engine in a module that never evaluates a regex. Confirmed by parsing the published artifact's data section: it contained `regex-syntax`'s property-name tables (`ASCII_Hex_Digit`, `Bidi_Class`, `Bidi_Mirrored`), script long names (`Anatolian_Hieroglyphs`, `Caucasian_Albanian`) and general-category tables (`Close_Punctuation`, `Connector_Punctuation`). After this change all three groups of markers are gone from the artifact.

## Why it is safe

Upstream built this exact escape hatch: `libdd-common`'s `regex_engine` module re-exports either `regex` or `regex_lite`, and its only `use regex::` is inside that cfg gate.

- `libdd-trace-obfuscation` (`replacer.rs`, `ip_address.rs`) and `libdd-trace-utils::trace_filter` import `libdd_common::regex_engine`, not `regex` directly.
- The call sites that compile *user-supplied* patterns — `replacer.rs:42`/`:126` and `trace_filter.rs:145`/`:172` — are not reachable from this module. Obfuscation in `libdd-data-pipeline` sits behind its `stats-obfuscation` feature, which we do not enable (`default-features = false`), and `crates/pipeline/src/stats.rs` already documents stats obfuscation as disabled. Nothing in `crates/pipeline` or `crates/capabilities` constructs a `Regex` or calls `trace_filter`. That unreachability is exactly why LTO can drop the engine.
- `require-regex-full`, which would override `regex-lite`, is only enabled by `datadog-ffe` — not in this dependency graph (0 dependency paths to `pipeline`).
- Grepped the obfuscation and filter sources for constructs `regex-lite` does not support (`\p{…}`, look-around, backreferences): none present.

`regex` stays in `Cargo.lock` because it is still a non-optional dependency of `libdd-common`; the win comes from it becoming unreferenced and being dead-stripped. The lockfile gains `regex-lite 0.1.9`.

## Verification

Built locally on macOS (`node scripts/build-wasm.js pipeline`) before and after, then ran `wasm-opt` over both to match the CI artifact.

- `node --test --test-force-exit test/pipeline.js` → **51/51 pass**
- `node --test --test-force-exit test/http_transport.js` → **18/18 pass**

## Rejected: `wasm-opt -Oz`

I also measured raising the optimisation level, since `crates/pipeline/Cargo.toml` currently sets `wasm-opt = ['-O', '--all-features']`. Not worth it — on the same input `-Oz` saves 2.2% raw and is **larger on the wire**:

| | raw | gzip |
| --- | --- | --- |
| unoptimised | 1,657,600 | 552,858 |
| `-O` | 1,507,189 | 564,771 |
| `-Oz` | 1,474,098 | 568,015 |

wasm-opt's transforms trade compressibility for raw size here, so `-O` stays. (Note both optimised builds gzip *worse* than the unoptimised module — worth revisiting separately if download size is what we care about, since npm ships gzipped tarballs.)

## Follow-ups not in this PR

- Two `hashbrown` versions (`0.15.5` and `0.17.0`) resolve in the graph, so two hash-table implementations compile in — needs upstream version alignment.
- The `http` crate's standard-header table appeared twice in the published data section, and `http::header::name::StandardHeader::from_bytes` is a single 12,120-byte function.
- ~33 KB of embedded panic-location strings (absolute `~/.cargo/git/checkouts/libdatadog-…` paths).
- Making `regex` optional in `libdd-common` upstream would remove it from the lockfile rather than relying on dead-code elimination.
