### PR TITLE
feat: add DDSketch WASM bindings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
           - library_config
           - datadog-js-zstd
           - pipeline
+          - sketches
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: 'Use composite action'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
           - library_config
           - datadog-js-zstd
           - pipeline
+          - sketches
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: 'Use composite action'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,6 +2334,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "sketches"
+version = "0.1.0"
+dependencies = [
+ "libdd-ddsketch 1.1.0",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/sketches/Cargo.toml
+++ b/crates/sketches/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "sketches"
+version = "0.1.0"
+edition = "2021"
+description = "Wasm bindings for Datadog's DDSketch"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+libdd-ddsketch = { git = "https://github.com/DataDog/libdatadog.git", rev = "3081603d3c74f209be4e3be951f78a1a7469397f" }
+wasm-bindgen = "0.2"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]

--- a/crates/sketches/src/lib.rs
+++ b/crates/sketches/src/lib.rs
@@ -1,0 +1,63 @@
+use libdd_ddsketch::DDSketch as InnerDDSketch;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+#[derive(Default)]
+pub struct DDSketch {
+    inner: InnerDDSketch,
+}
+
+#[wasm_bindgen]
+impl DDSketch {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add(&mut self, point: f64) -> Result<(), JsError> {
+        self.inner
+            .add(point)
+            .map_err(|error| JsError::new(&error.to_string()))
+    }
+
+    #[wasm_bindgen(js_name = addWithCount)]
+    pub fn add_with_count(&mut self, point: f64, count: f64) -> Result<(), JsError> {
+        self.inner
+            .add_with_count(point, count)
+            .map_err(|error| JsError::new(&error.to_string()))
+    }
+
+    pub fn count(&self) -> f64 {
+        self.inner.count()
+    }
+
+    pub fn encode(self) -> Vec<u8> {
+        self.inner.encode_to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adds_points_and_counts() {
+        let mut sketch = DDSketch::new();
+
+        sketch.add(1.0).unwrap();
+        sketch.add_with_count(2.0, 3.0).unwrap();
+
+        assert_eq!(sketch.count(), 4.0);
+    }
+
+    #[test]
+    fn encodes_as_protobuf() {
+        let mut sketch = DDSketch::new();
+        sketch.add_with_count(42.0, 2.0).unwrap();
+
+        let encoded = sketch.encode();
+        let decoded = InnerDDSketch::from_encoded(&encoded).unwrap();
+
+        assert_eq!(decoded.count(), 2.0);
+    }
+}

--- a/crates/sketches/src/lib.rs
+++ b/crates/sketches/src/lib.rs
@@ -35,35 +35,3 @@ impl DDSketch {
         self.inner.clone().encode_to_vec()
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn adds_points_and_counts() {
-        let mut sketch = DDSketch::new();
-
-        sketch.add(1.0).unwrap();
-        sketch.add_with_count(2.0, 3.0).unwrap();
-
-        assert_eq!(sketch.count(), 4.0);
-    }
-
-    #[test]
-    fn encodes_as_protobuf_without_consuming_the_sketch() {
-        let mut sketch = DDSketch::new();
-        sketch.add_with_count(42.0, 2.0).unwrap();
-
-        let encoded = sketch.encode();
-        let decoded = InnerDDSketch::from_encoded(&encoded).unwrap();
-
-        assert_eq!(decoded.count(), 2.0);
-
-        sketch.add(43.0).unwrap();
-        let encoded = sketch.encode();
-        let decoded = InnerDDSketch::from_encoded(&encoded).unwrap();
-
-        assert_eq!(decoded.count(), 3.0);
-    }
-}

--- a/crates/sketches/src/lib.rs
+++ b/crates/sketches/src/lib.rs
@@ -31,8 +31,8 @@ impl DDSketch {
         self.inner.count()
     }
 
-    pub fn encode(self) -> Vec<u8> {
-        self.inner.encode_to_vec()
+    pub fn encode(&self) -> Vec<u8> {
+        self.inner.clone().encode_to_vec()
     }
 }
 
@@ -51,7 +51,7 @@ mod tests {
     }
 
     #[test]
-    fn encodes_as_protobuf() {
+    fn encodes_as_protobuf_without_consuming_the_sketch() {
         let mut sketch = DDSketch::new();
         sketch.add_with_count(42.0, 2.0).unwrap();
 
@@ -59,5 +59,11 @@ mod tests {
         let decoded = InnerDDSketch::from_encoded(&encoded).unwrap();
 
         assert_eq!(decoded.count(), 2.0);
+
+        sketch.add(43.0).unwrap();
+        let encoded = sketch.encode();
+        let decoded = InnerDDSketch::from_encoded(&encoded).unwrap();
+
+        assert_eq!(decoded.count(), 3.0);
     }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-debug": "mkdir -p target && yarn -s cargo-build > ./target/out.ndjson && yarn -s copy-artifacts",
     "build-release": "mkdir -p target && yarn -s cargo-build-release > ./target/out.ndjson && yarn -s copy-artifacts",
     "build-all": "mkdir -p target && yarn -s cargo-build -- --workspace > ./target/out.ndjson && yarn -s copy-artifacts && yarn -s build-wasm",
-    "build-wasm": "yarn -s install-wasm-pack && node scripts/build-wasm.js library_config && node scripts/build-wasm.js datadog-js-zstd && node scripts/build-wasm.js pipeline",
+    "build-wasm": "yarn -s install-wasm-pack && node scripts/build-wasm.js library_config && node scripts/build-wasm.js datadog-js-zstd && node scripts/build-wasm.js pipeline && node scripts/build-wasm.js sketches",
     "cargo-build-release": "yarn -s cargo-build -- --release",
     "cargo-build": "cargo build --message-format=json-render-diagnostics",
     "copy-artifacts": "node ./scripts/copy-artifacts",

--- a/test/wasm/sketches/index.js
+++ b/test/wasm/sketches/index.js
@@ -18,3 +18,12 @@ assert.throws(() => sketch.addWithCount(1, Number.NaN), /count is invalid/)
 const encoded = sketch.encode()
 assert(encoded instanceof Uint8Array)
 assert(encoded.length > 0)
+
+assert.strictEqual(sketch.count(), 4)
+sketch.add(3)
+assert.strictEqual(sketch.count(), 5)
+
+const reencoded = sketch.encode()
+assert(reencoded instanceof Uint8Array)
+assert(reencoded.length > 0)
+assert.strictEqual(sketch.count(), 5)

--- a/test/wasm/sketches/index.js
+++ b/test/wasm/sketches/index.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const assert = require('node:assert')
+
+const loader = require('../../../load')
+const { DDSketch } = loader.load('sketches')
+
+const sketch = new DDSketch()
+assert.strictEqual(sketch.count(), 0)
+
+sketch.add(1)
+sketch.addWithCount(2, 3)
+assert.strictEqual(sketch.count(), 4)
+
+assert.throws(() => sketch.add(-1), /point is invalid/)
+assert.throws(() => sketch.addWithCount(1, Number.NaN), /count is invalid/)
+
+const encoded = sketch.encode()
+assert(encoded instanceof Uint8Array)
+assert(encoded.length > 0)


### PR DESCRIPTION
Adds a small sketches WASM crate backed by libdd-ddsketch. The crate exposes a minimal DDSketch API for Node.js.