### PR TITLE
build: simplify WASM build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build-debug": "mkdir -p target && yarn -s cargo-build > ./target/out.ndjson && yarn -s copy-artifacts",
     "build-release": "mkdir -p target && yarn -s cargo-build-release > ./target/out.ndjson && yarn -s copy-artifacts",
     "build-all": "mkdir -p target && yarn -s cargo-build -- --workspace > ./target/out.ndjson && yarn -s copy-artifacts && yarn -s build-wasm",
-    "build-wasm": "yarn -s install-wasm-pack && node scripts/build-wasm.js library_config && node scripts/build-wasm.js datadog-js-zstd && node scripts/build-wasm.js pipeline && node scripts/build-wasm.js sketches",
+    "build-wasm": "yarn -s install-wasm-pack && node scripts/build-wasm.js",
     "cargo-build-release": "yarn -s cargo-build -- --release",
     "cargo-build": "cargo build --message-format=json-render-diagnostics",
     "copy-artifacts": "node ./scripts/copy-artifacts",

--- a/scripts/build-wasm.js
+++ b/scripts/build-wasm.js
@@ -15,7 +15,12 @@ const childProcess = require('node:child_process')
 
 const isMacOS = os.platform() === 'darwin'
 const noWasmOpt = isMacOS ? '--no-opt' : ''
-const library = process.argv[2]
+const libraries = [
+  'library_config',
+  'datadog-js-zstd',
+  'pipeline',
+  'sketches',
+]
 
 const env = {
   ...process.env,
@@ -44,8 +49,10 @@ if (isMacOS) {
   env.CXX_wasm32_unknown_unknown = `${llvmBinDir}/clang++`
 }
 
-childProcess.execSync(
-  `wasm-pack build ${noWasmOpt} --target nodejs ./crates/${library} --out-dir ../../prebuilds/${library}`, {
-    env,
-  },
-)
+for (const library of libraries) {
+  childProcess.execSync(
+    `wasm-pack build ${noWasmOpt} --target nodejs ./crates/${library} --out-dir ../../prebuilds/${library}`, {
+      env,
+    },
+  )
+}


### PR DESCRIPTION
Move the list of WASM crates into build-wasm.js and build them sequentially in a loop.